### PR TITLE
fix(flag): loosen naming restrictions for flags to include periods

### DIFF
--- a/flag/flagset.go
+++ b/flag/flagset.go
@@ -324,10 +324,10 @@ func (f *FlagSet) Var(value Value, name string, usage string) {
 	}
 
 	invalid := strings.ContainsFunc(name, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-'
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-' && r != '.'
 	})
 	if invalid {
-		panic(fmt.Sprintf("flag '%s' has invalid name (must be alphanumeric and '-')", name))
+		panic(fmt.Sprintf("flag '%s' has invalid name (must be alphanumeric and any of '-.')", name))
 	}
 
 	if f.Lookup(name) != nil {

--- a/flag/flagset_test.go
+++ b/flag/flagset_test.go
@@ -70,6 +70,17 @@ func TestFlagSet(t *testing.T) {
 				t.Fatalf("count var not updated with expected default value")
 			}
 		})
+
+		t.Run("should allow flag names with periods", func(t *testing.T) {
+			var addr string
+
+			fs := NewFlagSet("test", ContinueOnError)
+			fs.StringVar(&addr, "web.listen-address", ":8080", "bind `address` for the web server")
+
+			if addr != ":8080" {
+				t.Fatalf("addr var not updated with expected default value")
+			}
+		})
 	})
 
 	t.Run("Lookup", func(t *testing.T) {


### PR DESCRIPTION
Allow flag names to include periods, which is often desired for organizing flags (e.g. 'web.bind-address').