### PR TITLE
chore: improve command usage formatting, documentation and examples

### DIFF
--- a/command.go
+++ b/command.go
@@ -126,16 +126,16 @@ type BaseCommand struct {
 	// The command name. See Name() in [Command].
 	CommandName string
 
-	// Optional function invoked by the default InitializeFlags() function. If nil, InitializeFlags() will do nothing.
+	// Optional function invoked by the default InitializeFlags() function.
 	InitFlagsFunc func(*flag.FlagSet)
 
-	// Optional function invoked by the default Initialize() function. If nil, Initialize() will return nil.
+	// Optional function invoked by the default Initialize() function.
 	InitFunc func(context.Context, []string) error
 
-	// Optional function invoked by the default Run() function. If nil, Run() will return nil.
+	// Optional function invoked by the default Run() function.
 	RunFunc func(context.Context, []string) error
 
-	// Optional function invoked by the default Destroy() function. If nil, Destroy() will return nil.
+	// Optional function invoked by the default Destroy() function.
 	DestroyFunc func(context.Context, []string) error
 
 	// Subcommands for this command, if applicable. See [RootCommand].

--- a/flag/doc.go
+++ b/flag/doc.go
@@ -49,7 +49,8 @@ character, while a short flag has a name with a single character.
 	--count 12  // long integer value
 	--count=12  // long integer value with immediate value
 
-Multiple short flags may be "stuck" together.
+Short boolean flags may be combined into a single argument, and short flags accepting arguments may be "stuck" to the
+value:
 
 	-ac12       // equivalent to '-a -c 12'
 

--- a/flag/example_flagset_aliases_test.go
+++ b/flag/example_flagset_aliases_test.go
@@ -1,0 +1,40 @@
+package flag_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/brandon1024/cmder/flag"
+)
+
+// Two flags with the same [Value] can be used to create shorthand aliases for longer flags. For example, you may want
+// to provide a shorthand `-u` for the longer `--until` flag. Simply use [FlagSet.Lookup] to fetch the flag and
+// [FlagSet.Var] to create the shorthand.
+func ExampleFlagSet() {
+	var since, until time.Duration
+
+	fs := flag.NewFlagSet("alises", flag.ContinueOnError)
+	fs.DurationVar(&since, "since", -time.Minute, "show items since")
+	fs.Var(alias(fs.Lookup("since"), "s"))
+	fs.DurationVar(&until, "until", time.Duration(0), "show items until")
+	fs.Var(alias(fs.Lookup("until"), "u"))
+
+	args := []string{
+		"--since=-12m", "-u", "1m",
+	}
+
+	if err := fs.Parse(args); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("since: %s\n", since.String())
+	fmt.Printf("until: %s\n", until.String())
+
+	// Output:
+	// since: -12m0s
+	// until: 1m0s
+}
+
+func alias(flg *flag.Flag, name string) (flag.Value, string, string) {
+	return flg.Value, name, flg.Usage
+}

--- a/flag/example_value_test.go
+++ b/flag/example_value_test.go
@@ -1,0 +1,55 @@
+package flag_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/brandon1024/cmder/flag"
+)
+
+// TimeVar is a [flag.Value] for flags that accept timestamps in [time.RFC3339] format. TimeVar also implements
+// [Flag.Getter].
+type TimeVar time.Time
+
+// String returns the [time.RFC3339] representation of the timestamp flag.
+func (t *TimeVar) String() string {
+	return time.Time(*t).Format(time.RFC3339)
+}
+
+// Set fulfills the [flag.Value] interface. The given value must be a correctly formatted [time.RFC3339] timestamp.
+func (t *TimeVar) Set(value string) error {
+	tm, err := time.Parse(time.RFC3339, value)
+	if err == nil {
+		*t = TimeVar(tm)
+	}
+
+	return err
+}
+
+// Get fulfills the [flag.Getter] interface, allowing typed access to the flag value. In this case, returns a
+// [time.Time].
+func (t *TimeVar) Get() any {
+	return time.Time(*t)
+}
+
+// You can define custom types implementing [flag.Value] to handle different types of flags, like timestamps, IP
+// addresses, string maps or slices.
+func ExampleValue() {
+	var since TimeVar
+
+	fs := flag.NewFlagSet("custom", flag.ContinueOnError)
+	fs.Var(&since, "since", "show items since")
+
+	args := []string{
+		"--since", "2025-01-01T00:00:00Z",
+	}
+
+	if err := fs.Parse(args); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("since: %s\n", since.String())
+
+	// Output:
+	// since: 2025-01-01T00:00:00Z
+}

--- a/flag/flagset.go
+++ b/flag/flagset.go
@@ -47,7 +47,8 @@ var Usage = func() {
 // Unlike FlagSet in the standard library package, this FlagSet parses flags with POSIX/GNU semantics.
 //
 // [Flag] names must be unique within a FlagSet. An attempt to define a flag whose name is already in use will cause a
-// panic.
+// panic. Flag names must also be comprised of only alphanumeric characters, hyphens '-' (except at beginning or end of
+// name), and periods '.'
 type FlagSet struct {
 	// Usage is a function called when an error occurs while parsing flags. It is invoked directly after an error is
 	// encountered, but immediately before [FlagSet.Parse] returns the error or exits/panics (see [ErrorHandling]).

--- a/flag/flagset_test.go
+++ b/flag/flagset_test.go
@@ -557,6 +557,25 @@ func TestFlagSet(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+
+		t.Run("should support shorthand flag aliasing", func(t *testing.T) {
+			var output string
+
+			fs := NewFlagSet("test", ContinueOnError)
+			fs.StringVar(&output, "output", "-", "output `file`")
+
+			flg := fs.Lookup("output")
+			fs.Var(flg.Value, "o", flg.Usage)
+
+			err := fs.Parse([]string{"--output=test.out", "-o", "test-1.out"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if output != "test-1.out" {
+				t.Fatalf("output var not updated with expected value: %s", output)
+			}
+		})
 	})
 
 	t.Run("PrintDefaults", func(t *testing.T) {

--- a/usage_test.go
+++ b/usage_test.go
@@ -57,24 +57,20 @@ Examples:
   test --poll-interval <sec> --web.disable-exporter-metrics
 
 Flags:
-   -a <string>
-        address and port of the device (e.g. 192.168.1.1:4567)
-  --addr <string>
-        address and port of the device (e.g. 192.168.1.1:4567)
-  --poll-interval <duration> (default 0s)
-        attempt to poll the device status more frequently than advertised
-  --reconnect-interval <duration> (default 1m0s)
-        interval between connection attempts (e.g. 1m)
-   -s <string>
-        serial number of the device (e.g. 10293894a)
-  --serial-number <string>
-        serial number of the device (e.g. 10293894a)
+  -a <string>, --addr=<string>
+      address and port of the device (e.g. 192.168.1.1:4567)
+  --poll-interval=<duration> (default 0s)
+      attempt to poll the device status more frequently than advertised
+  --reconnect-interval=<duration> (default 1m0s)
+      interval between connection attempts (e.g. 1m)
+  -s <string>, --serial-number=<string>
+      serial number of the device (e.g. 10293894a)
   --web.disable-exporter-metrics (default false)
-        exclude metrics about the exporter itself (go_*)
-  --web.listen-address <string> (default :9090)
-        address on which to expose metrics
-  --web.telemetry-path <string> (default /metrics)
-        path under which to expose metrics
+      exclude metrics about the exporter itself (go_*)
+  --web.listen-address=<string> (default :9090)
+      address on which to expose metrics
+  --web.telemetry-path=<string> (default /metrics)
+      path under which to expose metrics
 `
 
 const ExpectedStdFlagUsageTemplate = `usage: test [flags] [args]
@@ -111,9 +107,10 @@ func TestUsage(t *testing.T) {
 	}
 
 	cmd.fs.String("serial-number", "", "serial number of the device (e.g. 10293894a)")
-	cmd.fs.String("s", "", "serial number of the device (e.g. 10293894a)")
+	cmd.fs.Var(alias(cmd.fs.Lookup("serial-number"), "s"))
 	cmd.fs.String("addr", "", "address and port of the device (e.g. 192.168.1.1:4567)")
-	cmd.fs.String("a", "", "address and port of the device (e.g. 192.168.1.1:4567)")
+	cmd.fs.Var(alias(cmd.fs.Lookup("addr"), "a"))
+
 	cmd.fs.Duration("poll-interval", time.Duration(0), "attempt to poll the device status more frequently than advertised")
 	cmd.fs.Duration("reconnect-interval", time.Minute, "interval between connection attempts (e.g. 1m)")
 	cmd.fs.String("web.listen-address", ":9090", "address on which to expose metrics")
@@ -151,4 +148,356 @@ func TestUsage(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestFlags(t *testing.T) {
+	cmd := command{
+		Command: &BaseCommand{
+			CommandName: "test",
+			Usage:       "test [flags] [args]",
+			ShortHelp:   "Usage text generation test",
+			Help:        desc,
+			Examples:    examples,
+		},
+	}
+
+	t.Run("should group bool flags", func(t *testing.T) {
+		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
+		cmd.fs.Bool("all", false, "bool flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("all"), "a"))
+		cmd.fs.Var(alias(cmd.fs.Lookup("a"), "l"))
+		cmd.fs.Bool("show", false, "bool flag")
+
+		groups := flags(cmd)
+		if len(groups) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", groups)
+		}
+
+		group, ok := groups["all"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 3 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "a" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "l" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[2].Name != "all" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+
+		group, ok = groups["show"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 1 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+	})
+
+	t.Run("should group string flags", func(t *testing.T) {
+		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
+		cmd.fs.String("from", "HEAD^", "string flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("from"), "b"))
+		cmd.fs.Var(alias(cmd.fs.Lookup("from"), "B"))
+		cmd.fs.String("to", "HEAD", "string flag")
+
+		groups := flags(cmd)
+		if len(groups) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", groups)
+		}
+
+		group, ok := groups["from"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 3 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "B" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "b" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[2].Name != "from" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+
+		group, ok = groups["to"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 1 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+	})
+
+	t.Run("should group duration flags", func(t *testing.T) {
+		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
+		cmd.fs.Duration("since", time.Minute, "duration flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("since"), "s"))
+		cmd.fs.Var(alias(cmd.fs.Lookup("since"), "f"))
+		cmd.fs.Duration("until", time.Duration(0), "duration flag")
+
+		groups := flags(cmd)
+		if len(groups) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", groups)
+		}
+
+		group, ok := groups["since"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 3 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "f" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "s" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[2].Name != "since" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+
+		group, ok = groups["until"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 1 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+	})
+
+	t.Run("should group float flags", func(t *testing.T) {
+		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
+		cmd.fs.Float64("epsilon", 0.00001, "float64 flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("epsilon"), "e"))
+		cmd.fs.Var(alias(cmd.fs.Lookup("e"), "ep"))
+		cmd.fs.Float64("gamma", 0.01, "float64 flag")
+
+		groups := flags(cmd)
+		if len(groups) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", groups)
+		}
+
+		group, ok := groups["epsilon"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 3 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "e" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "ep" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[2].Name != "epsilon" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+
+		group, ok = groups["gamma"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 1 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+	})
+
+	t.Run("should group int flags", func(t *testing.T) {
+		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
+		cmd.fs.Int("page", 0, "int flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("page"), "p"))
+		cmd.fs.Int("count", 100, "int flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("count"), "c"))
+
+		groups := flags(cmd)
+		if len(groups) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", groups)
+		}
+
+		group, ok := groups["page"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "p" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "page" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+
+		group, ok = groups["count"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "c" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "count" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+	})
+
+	t.Run("should group int64 flags", func(t *testing.T) {
+		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
+		cmd.fs.Int64("page", 0, "int64 flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("page"), "a"))
+		cmd.fs.Int64("count", 100, "int64 flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("count"), "b"))
+
+		groups := flags(cmd)
+		if len(groups) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", groups)
+		}
+
+		group, ok := groups["page"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "a" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "page" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+
+		group, ok = groups["count"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "b" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "count" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+	})
+
+	t.Run("should group uint flags", func(t *testing.T) {
+		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
+		cmd.fs.Uint("page", 0, "uint flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("page"), "x"))
+		cmd.fs.Uint("count", 100, "uint flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("count"), "y"))
+
+		groups := flags(cmd)
+		if len(groups) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", groups)
+		}
+
+		group, ok := groups["page"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "x" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "page" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+
+		group, ok = groups["count"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "y" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "count" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+	})
+
+	t.Run("should group uint64 flags", func(t *testing.T) {
+		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
+		cmd.fs.Uint64("page", 0, "uint64 flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("page"), "px"))
+		cmd.fs.Uint64("count", 100, "uint64 flag")
+		cmd.fs.Var(alias(cmd.fs.Lookup("count"), "cx"))
+
+		groups := flags(cmd)
+		if len(groups) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", groups)
+		}
+
+		group, ok := groups["page"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "px" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "page" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+
+		group, ok = groups["count"]
+		if !ok {
+			t.Fatalf("no group found")
+		}
+		if len(group) != 2 {
+			t.Fatalf("unexpected number of flag groups: %v", group)
+		}
+		if group[0].Name != "cx" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+		if group[1].Name != "count" {
+			t.Fatalf("unexpected sort order in flag group")
+		}
+	})
+
+	t.Run("should not group func flags which are not comparable", func(t *testing.T) {
+		fn1 := func(v string) error {
+			return nil
+		}
+		fn2 := func(v string) error {
+			return nil
+		}
+
+		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
+		cmd.fs.BoolFunc("verbose", "boolfunc flag", fn1)
+		cmd.fs.Var(alias(cmd.fs.Lookup("verbose"), "v"))
+		cmd.fs.Func("optimize", "func flag", fn2)
+		cmd.fs.Var(alias(cmd.fs.Lookup("optimize"), "O"))
+
+		groups := flags(cmd)
+		if len(groups) != 4 {
+			t.Fatalf("unexpected number of flag groups: %v", groups)
+		}
+	})
+}
+
+func alias(flg *flag.Flag, name string) (flag.Value, string, string) {
+	return flg.Value, name, flg.Usage
 }


### PR DESCRIPTION
Improve the template for rendering command usage to better organize flags. Flags are now grouped together by flag value equivalence so that it's easier to pick out which shorthand flags are aliases of other longer flags.

Additionally, documentation has been improved and new examples have been added.