### PR TITLE
feat: introduce execute option for binding env vars to flags

### DIFF
--- a/example_bind_env_test.go
+++ b/example_bind_env_test.go
@@ -1,0 +1,96 @@
+package cmder_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/brandon1024/cmder"
+)
+
+const BindEnvUsageLine = `bind-env [subcommand] [flags]`
+
+const BindEnvShortHelpText = `Simple demonstration of binding environment variables to command flags.`
+
+const BindEnvHelpText = `
+'bind-env' desmonstrates how cmder can be configured to bind environment variables to flags. Explicit command-line
+arguments always take precedence over environment variables.
+`
+
+const BindEnvExamples = `
+# print all default flag values
+bind-env show
+
+# print flag values from environment
+bind-env show
+
+# print flag values from environment
+bind-env show --
+`
+
+func GetCommand() *cmder.BaseCommand {
+	return &cmder.BaseCommand{
+		CommandName: "bind-env",
+		Children:    []cmder.Command{GetShowCommand()},
+		Usage:       BindEnvUsageLine,
+		ShortHelp:   BindEnvShortHelpText,
+		Help:        BindEnvHelpText,
+		Examples:    BindEnvExamples,
+	}
+}
+
+func GetShowCommand() *cmder.BaseCommand {
+	return &cmder.BaseCommand{
+		CommandName:   "show",
+		Usage:         `show [flags]`,
+		ShortHelp:     `Show flag values`,
+		Help:          `'show' dumps flag values to stdout.`,
+		Examples:      BindEnvExamples,
+		InitFlagsFunc: showFlags,
+		RunFunc:       show,
+	}
+}
+
+var (
+	format string = "default"
+	count  uint   = 10
+)
+
+func showFlags(fs *flag.FlagSet) {
+	fs.StringVar(&format, "format", format, "output format (default, pretty)")
+	fs.UintVar(&count, "page-count", count, "number of pages")
+}
+
+func show(ctx context.Context, args []string) error {
+	switch format {
+	case "default":
+		fmt.Printf("%v %v\n", format, count)
+	case "pretty":
+		fmt.Printf("format: %v\npage-count: %v\n", format, count)
+	default:
+		return fmt.Errorf("illegal format: %s", format)
+	}
+
+	return nil
+}
+
+func ExampleWithEnvironmentBinding() {
+	_ = os.Setenv("BINDENV_SHOW_FORMAT", "overidden-by-flag")
+	_ = os.Setenv("BINDENV_SHOW_PAGECOUNT", "20")
+
+	args := []string{"show", "--format=pretty"}
+
+	ops := []cmder.ExecuteOption{
+		cmder.WithArgs(args),
+		cmder.WithEnvironmentBinding(),
+	}
+
+	if err := cmder.Execute(context.Background(), GetCommand(), ops...); err != nil {
+		fmt.Printf("unexpected error occurred: %v", err)
+	}
+
+	// Output:
+	// format: pretty
+	// page-count: 20
+}

--- a/flags.go
+++ b/flags.go
@@ -5,12 +5,12 @@ import (
 )
 
 // FlagInitializer is an interface implemented by commands that need to register flags.
+//
+// InitializeFlags will be invoked during [Execute], prior to any lifecycle routines. You can use this to register
+// flags for your command.
+//
+// Help flags '-h' and '--help' are registered automatically and will instruct [Execute] to render usage information
+// to the [UsageOutputWriter].
 type FlagInitializer interface {
-	// InitializeFlags initializes flags. Invoked by [Execute] before any lifecycle routines.
-	//
-	// Help flags '-h' and '--help' are registered automatically and will instruct [Execute] to render usage information
-	// to the [UsageOutputWriter].
-	//
-	// See [Execute] for more information.
 	InitializeFlags(*flag.FlagSet)
 }

--- a/getopt/example_hide_test.go
+++ b/getopt/example_hide_test.go
@@ -22,24 +22,31 @@ func ExampleHide() {
 	fs.StringVar(&output, "output", "-", "output `file`")
 	fs.StringVar(&output, "o", "-", "output `file`")
 
+	// option 1: wrap the flag value
 	fs.Lookup("c").Value = &getopt.Hidden{fs.Lookup("c").Value}
+
+	// option 2: use getopt.Hide
 	getopt.Hide(fs.Lookup("o"))
+
+	// option 3: using FlagSet.Var
+	var since getopt.TimeVar
+	fs.Var(&getopt.Hidden{&since}, "since", "show items since")
 
 	fs.SetOutput(os.Stdout)
 	fs.PrintDefaults()
 
-	args := []string{"-c", "2025", "-o", "output.txt"}
+	args := []string{"-c", "2025", "-o", "output.txt", "--since", "2025-01-01T00:00:00Z"}
 
 	if err := fs.Parse(args); err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("values: %d %s\n", count, output)
+	fmt.Printf("values: %d %s %s\n", count, output, since.String())
 
 	// Output:
 	//   --count <number> (default 12)
 	//         number of results
 	//   --output <file> (default -)
 	//         output file
-	// values: 2025 output.txt
+	// values: 2025 output.txt 2025-01-01T00:00:00Z
 }

--- a/getopt/example_mapvar_test.go
+++ b/getopt/example_mapvar_test.go
@@ -21,7 +21,7 @@ func ExampleMapVar() {
 	args := []string{
 		"--variable", "key1=value1",
 		"-v", "key2=value2,key3=value3",
-		`--variable=hello=" HI, WORLD "`,
+		`--variable="hello= HI, WORLD "`,
 	}
 
 	if err := fs.Parse(args); err != nil {

--- a/getopt/example_stringsvar_test.go
+++ b/getopt/example_stringsvar_test.go
@@ -1,0 +1,35 @@
+package getopt_test
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/brandon1024/cmder/getopt"
+)
+
+// This example demonstrates usage of [getopt.StringsVar] for string slice flags. You'll often find string sliceee flags
+// on commands that accept IP addresses, for example.
+func ExampleStringsVar() {
+	hosts := getopt.StringsVar{}
+
+	fs := flag.NewFlagSet("stringsvar", flag.ContinueOnError)
+	fs.Var(&hosts, "broker", "connect to a broker")
+	fs.Var(&hosts, "b", "connect to a broker")
+
+	args := []string{
+		"--broker", "tcp://127.0.0.1",
+		"-b", "tls://broker-1.domain.example.com,tls://broker-2.domain.example.com",
+	}
+
+	if err := fs.Parse(args); err != nil {
+		panic(err)
+	}
+
+	for _, host := range hosts {
+		fmt.Printf("'%s'\n", host)
+	}
+	// Output:
+	// 'tcp://127.0.0.1'
+	// 'tls://broker-1.domain.example.com'
+	// 'tls://broker-2.domain.example.com'
+}

--- a/getopt/mapvar.go
+++ b/getopt/mapvar.go
@@ -1,87 +1,63 @@
 package getopt
 
 import (
+	"encoding/csv"
 	"fmt"
 	"maps"
 	"slices"
-	"strconv"
 	"strings"
-	"unicode"
 )
 
 // MapVar is a [flag.Value] for flags that accept map values. MapVar also implements [flag.Getter].
 //
 // MapVar parses flag values which are key=value pairs. Multiple key=value pairs may be comma separated (e.g.
-// key1=value1,key2=vlue2). Keys must be alphanumeric. Values can contain periods and whitespace if enclosed in double
-// quotes. Unquoted whitespace will be trimmed.
+// key1=value1,key2=value2). Keys should be alphanumeric. Values can contain commas and whitespace if enclosed in double
+// quotes.
 //
 //	key1=value1
 //	key1=value1,key2=value2
-//	key1 = "value, 1"
+//	"key1=value, 1","key2=value, 2"
 //	key1=v=1,key2=v=2
 type MapVar map[string]string
 
-// String returns the map, formatted as a set of key-value pairs:
+// String returns the map, formatted as a set of key-value pairs.
 func (m MapVar) String() string {
 	var entries []string
 
 	for _, k := range slices.Sorted(maps.Keys(m)) {
-		entries = append(entries, k+"="+strconv.Quote(m[k]))
+		entries = append(entries, k+"="+m[k])
 	}
 
-	return strings.Join(entries, ",")
+	var builder strings.Builder
+
+	w := csv.NewWriter(&builder)
+	if err := w.Write(entries); err != nil {
+		panic(err)
+	}
+
+	w.Flush()
+
+	if err := w.Error(); err != nil {
+		panic(err)
+	}
+
+	return strings.TrimSuffix(builder.String(), "\n")
 }
 
 // Set fulfills the [flag.Value] interface. The given value must be a set of key-value pairs.
 func (m MapVar) Set(value string) error {
-	var (
-		entries         = make(map[string]string)
-		quoted, inValue bool
-		key, val        string
-	)
+	r := csv.NewReader(strings.NewReader(value))
 
-	for pos, c := range value {
-		switch {
-		case c == '"' && !inValue:
-			return fmt.Errorf("illegal mapvar value at position %d (quoted key): %s", pos, value)
-		case !quoted && c == '"':
-			quoted = true
-		case quoted && c == '"':
-			quoted = false
-		case quoted && inValue:
-			val += string(c)
-		case quoted && !inValue:
-			return fmt.Errorf("illegal mapvar value at position %d (quoted key): %s", pos, value)
-		case unicode.IsSpace(c):
-		case !inValue && c == ',':
-			return fmt.Errorf("illegal mapvar value at position %d (malformed pair missing value): %s", pos, value)
-		case inValue && c == '=':
-			val += string(c)
-		case c == '=':
-			inValue = true
-		case c == ',':
-			entries[key] = val
-			key, val, inValue = "", "", false
-		case inValue:
-			val += string(c)
-		case !inValue:
-			key += string(c)
-		default:
-			panic(fmt.Errorf("bug: unhandled case: pos=%d, c=%v, quoted=%v, inValue=%v, key='%s', val='%s'",
-				pos, c, quoted, inValue, key, val))
-		}
+	pairs, err := r.ReadAll()
+	if err != nil {
+		return fmt.Errorf("getopt: malformed map value: %s", value)
+	}
+	if len(pairs) != 1 {
+		return fmt.Errorf("getopt: malformed map value: %s", value)
 	}
 
-	if quoted {
-		return fmt.Errorf("illegal mapvar value (quote mismatch): %s", value)
-	}
-	if !inValue {
-		return fmt.Errorf("illegal mapvar value (malformed pair missing value): %s", value)
-	}
-
-	entries[key] = val
-
-	for k, v := range entries {
+	for _, pair := range pairs[0] {
+		k, v, _ := strings.Cut(pair, "=")
 		m[k] = v
 	}
 

--- a/getopt/mapvar_test.go
+++ b/getopt/mapvar_test.go
@@ -18,37 +18,37 @@ func TestMapVar(t *testing.T) {
 					`HELLO`: `WORLD`,
 				},
 			}, {
+				args: []string{`-m`, `HELLO,WORLD`},
+				expected: map[string]string{
+					`HELLO`: ``,
+					`WORLD`: ``,
+				},
+			}, {
 				args: []string{`-m`, `HELLO=WORLD,HALLO=WELT`},
 				expected: map[string]string{
 					`HELLO`: `WORLD`,
 					`HALLO`: `WELT`,
 				},
 			}, {
-				args: []string{`-m`, `HELLO="WORLD,HALLO=WELT"`},
+				args: []string{`-m`, `"HELLO=WORLD,HALLO=WELT"`},
 				expected: map[string]string{
 					`HELLO`: `WORLD,HALLO=WELT`,
 				},
 			}, {
-				args: []string{`-m`, `HELLO="WORLD",HALLO=WELT`},
+				args: []string{`-m`, `"HELLO=WORLD",HALLO=WELT`},
 				expected: map[string]string{
 					`HELLO`: `WORLD`,
 					`HALLO`: `WELT`,
 				},
 			}, {
-				args: []string{`-m`, `HELLO=" HI, WORLD "`},
+				args: []string{`-m`, `"HELLO= HI, WORLD "`},
 				expected: map[string]string{
 					`HELLO`: ` HI, WORLD `,
 				},
 			}, {
 				args: []string{`-m`, `HELLO = WORLD`},
 				expected: map[string]string{
-					`HELLO`: `WORLD`,
-				},
-			}, {
-				args: []string{`-m`, `HELLO=WORLD`, `-m`, `HALLO=WELT`},
-				expected: map[string]string{
-					`HELLO`: `WORLD`,
-					`HALLO`: `WELT`,
+					`HELLO `: ` WORLD`,
 				},
 			}, {
 				args: []string{`-m`, `HELLO=WORLD`, `-m`, `HALLO=WELT`},
@@ -68,14 +68,9 @@ func TestMapVar(t *testing.T) {
 					`HELLO`: `world`,
 				},
 			}, {
-				args: []string{`-m`, `HELLO=" WOR "	LD`},
+				args: []string{`-m`, `"HELLO= WO 	R	LD  "`},
 				expected: map[string]string{
-					`HELLO`: ` WOR LD`,
-				},
-			}, {}, {
-				args: []string{`-m`, `HELLO=" WO "	"R"	LD " "`},
-				expected: map[string]string{
-					`HELLO`: ` WO RLD `,
+					`HELLO`: ` WO 	R	LD  `,
 				},
 			}, {
 				args: []string{`-m`, `HELLO=WORLD=HALLO`},
@@ -98,19 +93,28 @@ func TestMapVar(t *testing.T) {
 			if !maps.Equal(tt.expected, mv) {
 				t.Errorf("unexpected parsed args: %v (%v)", mv, tt.args)
 			}
+
+			// try parsing again from the output of [MapVar.String]
+			mv2 := MapVar{}
+
+			fs = flag.NewFlagSet("map", flag.ContinueOnError)
+			fs.Var(mv2, "m", "test")
+
+			if err := fs.Parse([]string{"-m", mv.String()}); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !maps.Equal(mv, mv2) {
+				t.Errorf("unexpected parsed args: %v (%v)", mv, tt.args)
+			}
 		}
 	})
 
 	t.Run("should error for malformed flags", func(t *testing.T) {
 		testcases := [][]string{
-			{`-m`, `HELLO`},
-			{`-m`, `HELLO,WORLD`},
-			{`-m`, `HELLO=WORLD,`},
 			{`-m`, `HELLO="WORLD`},
 			{`-m`, `HELLO=WORLD"`},
 			{`-m`, `"HELLO"=WORLD`},
-			{`-m`, `HELLO=WORLD,hi,HALLO=WELT`},
-			{`-m`, `,`},
 		}
 
 		for _, tt := range testcases {

--- a/getopt/stringsvar.go
+++ b/getopt/stringsvar.go
@@ -1,0 +1,61 @@
+package getopt
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strings"
+)
+
+// StringsVar is a [flag.Value] for flags that accept one or more string values. StringsVar also implements
+// [flag.Getter].
+//
+// StringsVar collects string arguments into a slice. Multiple string values may be comma separated (e.g.
+// value1,value2). Values containing commas may be enclosed in double quotes.
+//
+//	value
+//	value1,value2
+//	"value, 1","value, 2"
+type StringsVar []string
+
+// String returns the slice, formatted as comma-separated values.
+func (s StringsVar) String() string {
+	var builder strings.Builder
+
+	w := csv.NewWriter(&builder)
+	if err := w.Write([]string(s)); err != nil {
+		panic(err)
+	}
+
+	w.Flush()
+
+	if err := w.Error(); err != nil {
+		panic(err)
+	}
+
+	return builder.String()
+}
+
+// Set fulfills the [flag.Value] interface.
+func (s *StringsVar) Set(value string) error {
+	r := csv.NewReader(strings.NewReader(value))
+
+	values, err := r.ReadAll()
+	if err != nil {
+		return fmt.Errorf("getopt: malformed string slice value: %s", value)
+	}
+	if len(values) != 1 {
+		return fmt.Errorf("getopt: malformed string slice value: %s", value)
+	}
+
+	for _, val := range values[0] {
+		*s = append(*s, val)
+	}
+
+	return nil
+}
+
+// Get fulfills the [flag.Getter] interface, allowing typed access to the flag value. In this case, returns a
+// []string.
+func (s StringsVar) Get() any {
+	return []string(s)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/brandon1024/cmder
 
 go 1.24.0
 
-toolchain go1.25.6
+toolchain go1.25.7
 
 tool (
 	golang.org/x/tools/cmd/goimports

--- a/options.go
+++ b/options.go
@@ -2,7 +2,10 @@ package cmder
 
 // Options used to configure behaviour of [Execute].
 type ExecuteOptions struct {
-	args []string
+	args          []string
+	nativeFlags   bool
+	bindEnv       bool
+	bindEnvPrefix string
 }
 
 // A single option passed to [Execute].
@@ -13,5 +16,44 @@ type ExecuteOption func(*ExecuteOptions)
 func WithArgs(args []string) ExecuteOption {
 	return func(ops *ExecuteOptions) {
 		ops.args = args
+	}
+}
+
+// WithNativeFlags configures [Execute] to parse flags using the standard [flag] package instead of the default
+// [getopt] package.
+func WithNativeFlags() ExecuteOption {
+	return func(ops *ExecuteOptions) {
+		ops.nativeFlags = true
+	}
+}
+
+// WithEnvironmentBinding configures [Execute] to set flag values from the enclosing environment. Environment variables
+// are mapped to flags as follows:
+//
+//	COMMAND_FLAGNAME
+//	COMMAND_SUBCOMMAND_FLAGNAME
+//	COMMAND_SUBCOMMAND_SUBCOMMAND_FLAGNAME
+//
+// Command and flag names are all uppercased. Special characters are removed. Flags explicitly set at the command line
+// take precedence over environment variables.
+//
+//	git log --format=oneline   ->   GIT_LOG_FORMAT=oneline
+//	git log --no-abbrev-commit ->   GIT_LOG_NOABBREVCOMMIT=true
+func WithEnvironmentBinding() ExecuteOption {
+	return func(ops *ExecuteOptions) {
+		ops.bindEnv = true
+		ops.bindEnvPrefix = ""
+	}
+}
+
+// WithPrefixedEnvironmentBinding is like [WithEnvironmentBinding] but with a variable name prefix.
+//
+//	<PREFIX>COMMAND_FLAGNAME
+//	<PREFIX>COMMAND_SUBCOMMAND_FLAGNAME
+//	<PREFIX>COMMAND_SUBCOMMAND_SUBCOMMAND_FLAGNAME
+func WithPrefixedEnvironmentBinding(prefix string) ExecuteOption {
+	return func(ops *ExecuteOptions) {
+		ops.bindEnv = true
+		ops.bindEnvPrefix = prefix
 	}
 }


### PR DESCRIPTION
This revision introduces a handful of tweaks and improvements. The most notable is the new [WithEnvironmentBinding] option which instructs cmder to bind environment variables to flag values.

MapVar has also been reworked to use csv encoding for simplicity. Similarly, StringsVar was introduced for string slice flags.

The usage renderer has been fixed to compare map/slice/pointer types.

Go was updated to 1.25.7.