### PR TITLE
fix(getopt): drop trailing line feed from stringvar string func

### DIFF
--- a/getopt/stringsvar.go
+++ b/getopt/stringsvar.go
@@ -32,7 +32,7 @@ func (s StringsVar) String() string {
 		panic(err)
 	}
 
-	return builder.String()
+	return strings.TrimSuffix(builder.String(), "\n")
 }
 
 // Set fulfills the [flag.Value] interface.

--- a/getopt/timevar.go
+++ b/getopt/timevar.go
@@ -5,7 +5,7 @@ import (
 )
 
 // TimeVar is a [flag.Value] for flags that accept timestamps in [time.RFC3339] format. TimeVar also implements
-// [Flag.Getter].
+// [flag.Getter].
 type TimeVar time.Time
 
 // String returns the [time.RFC3339] representation of the timestamp flag.

--- a/usage.go
+++ b/usage.go
@@ -191,7 +191,7 @@ func areSame(f1, f2 flag.Value) bool {
 		return false
 	}
 
-	if !slices.Contains([]reflect.Kind{reflect.Map, reflect.Pointer, reflect.Slice}, ref1.Kind()) {
+	if !slices.Contains([]reflect.Kind{reflect.Map, reflect.Pointer, reflect.Func, reflect.Slice}, ref1.Kind()) {
 		return false
 	}
 


### PR DESCRIPTION
The [StringVar.String] method returned a value with a trailing line feed. This has been correted.