### PR TITLE
feat: add exec option for parsing interspersed arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ func run(ctx context.Context, args []string) error {
 }
 
 func main() {
-	cmd := cmder.BaseCommand{
+	cmd := &cmder.BaseCommand{
 		CommandName: "hello-world",
 		Usage:       "hello-world [<args>...]",
 		ShortHelp:   "Simple demonstration of cmder",

--- a/command.go
+++ b/command.go
@@ -119,6 +119,14 @@ type Documented interface {
 	Hidden() bool
 }
 
+// Compile-time checks.
+var (
+	_ Command           = &BaseCommand{}
+	_ RunnableLifecycle = &BaseCommand{}
+	_ RootCommand       = &BaseCommand{}
+	_ FlagInitializer   = &BaseCommand{}
+)
+
 // BaseCommand is an implementation of the [Command], [RunnableLifecycle], [RootCommand] and [FlagInitializer]
 // interfaces and may be embedded in your command types to reduce boilerplate.
 type BaseCommand struct {

--- a/example_bind_env_test.go
+++ b/example_bind_env_test.go
@@ -21,12 +21,11 @@ arguments always take precedence over environment variables.
 const BindEnvExamples = `
 # print all default flag values
 bind-env show
+> default 10
 
 # print flag values from environment
-bind-env show
-
-# print flag values from environment
-bind-env show --
+BINDENV_SHOW_FORMAT=pretty BINDENV_SHOW_PAGECOUNT=20 bind-env show --page-count=15
+> pretty 15
 `
 
 func GetCommand() *cmder.BaseCommand {

--- a/example_interspersed_test.go
+++ b/example_interspersed_test.go
@@ -1,0 +1,97 @@
+package cmder_test
+
+import (
+	"context"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"hash"
+
+	"github.com/brandon1024/cmder"
+)
+
+const usage = `hash [<str>...] [<flags>...]`
+
+const short = `Simple demonstration of interspersed arg parsing.`
+
+const desc = `
+'hash' desmonstrates how cmder can be configured to parse args with interspersed args and flags. The command accepts one
+or more strings and generates a hash of the result.
+`
+
+const examples = `
+# with interspersed args
+hash string-1 -a md5 string-2 -c 10 string-3
+
+# without interspersed args
+hash -a md5 -c 10 string-1 string-2 string-3
+`
+
+type hasher struct {
+	cmder.BaseCommand
+
+	algo   string
+	rounds uint
+}
+
+var (
+	cmd cmder.Command = &hasher{
+		BaseCommand: cmder.BaseCommand{
+			CommandName: "hash",
+			Usage:       usage,
+			ShortHelp:   short,
+			Help:        desc,
+			Examples:    examples,
+		},
+		algo:   "sha256",
+		rounds: 1,
+	}
+)
+
+func (h *hasher) InitializeFlags(fs *flag.FlagSet) {
+	fs.StringVar(&h.algo, "algo", h.algo, "select hashing algorithm (md5, sha1, sha256)")
+	fs.StringVar(&h.algo, "a", h.algo, "select hashing algorithm (md5, sha1, sha256)")
+	fs.UintVar(&h.rounds, "rounds", h.rounds, "number of hashing rounds")
+	fs.UintVar(&h.rounds, "c", h.rounds, "number of hashing rounds")
+}
+
+func (h *hasher) Run(ctx context.Context, args []string) error {
+	algos := map[string]hash.Hash{
+		"md5":    md5.New(),
+		"sha1":   sha1.New(),
+		"sha256": sha256.New(),
+	}
+
+	alg, ok := algos[h.algo]
+	if !ok {
+		return fmt.Errorf("no such algorithm: %s", h.algo)
+	}
+
+	for range h.rounds {
+		for _, s := range args {
+			alg.Write([]byte(s))
+		}
+	}
+
+	fmt.Printf("%x\n", alg.Sum(nil))
+
+	return nil
+}
+
+func ExampleWithInterspersedArgs() {
+	args := []string{"string-1", "-a", "md5", "string-2", "-c10", "string-3"}
+
+	ops := []cmder.ExecuteOption{
+		cmder.WithArgs(args),
+		cmder.WithInterspersedArgs(),
+	}
+
+	if err := cmder.Execute(context.Background(), cmd, ops...); err != nil {
+		fmt.Printf("unexpected error occurred: %v", err)
+	}
+
+	// Output:
+	// 0559406fc9a7b5704464c303ebbba64c
+}

--- a/execute_test.go
+++ b/execute_test.go
@@ -1,0 +1,114 @@
+package cmder
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"slices"
+	"testing"
+)
+
+func TestExecute(t *testing.T) {
+	t.Run("interspersed", func(t *testing.T) {
+		var (
+			l0f0, l0f1 uint
+			l1f0, l1f1 string
+			l2f0, l2f1 int
+		)
+
+		var result []string
+
+		cmd := &BaseCommand{
+			CommandName: "l0",
+			InitFlagsFunc: func(fs *flag.FlagSet) {
+				fs.UintVar(&l0f0, "l0f0", l0f0, "l0f0")
+				fs.UintVar(&l0f1, "l0f1", l0f1, "l0f1")
+			},
+			Children: []Command{
+				&BaseCommand{
+					CommandName: "l1",
+					InitFlagsFunc: func(fs *flag.FlagSet) {
+						fs.StringVar(&l1f0, "l1f0", l1f0, "l1f0")
+						fs.StringVar(&l1f1, "l1f1", l1f1, "l1f1")
+					},
+					Children: []Command{
+						&BaseCommand{
+							CommandName: "l2",
+							InitFlagsFunc: func(fs *flag.FlagSet) {
+								fs.IntVar(&l2f0, "l2f0", l2f0, "l2f0")
+								fs.IntVar(&l2f1, "l2f1", l2f1, "l2f1")
+							},
+							RunFunc: func(ctx context.Context, args []string) error {
+								result = args
+								return nil
+							},
+						},
+					},
+				},
+			},
+		}
+
+		t.Run("should parse interspersed args", func(t *testing.T) {
+			l0f0, l0f1, l1f0, l1f1, l2f0, l2f1 = 0, 0, "", "", 0, 0
+			result = nil
+
+			err := Execute(t.Context(), cmd, WithInterspersedArgs(), WithArgs([]string{
+				"--l0f0", "255", "--l0f1=27",
+				"l1", "--l1f0", "254", "--l1f1=26",
+				"l2", "--l2f0=253", "000", "--l2f1", "25", "111", "--", "--l2f0=255",
+			}))
+
+			assert(t, nilerr(err))
+			assert(t, eq(255, l0f0))
+			assert(t, eq(27, l0f1))
+			assert(t, eq("254", l1f0))
+			assert(t, eq("26", l1f1))
+			assert(t, eq(253, l2f0))
+			assert(t, eq(25, l2f1))
+			assert(t, match([]string{"000", "111", "--l2f0=255"}, result))
+		})
+
+		t.Run("should not parse interspersed by default", func(t *testing.T) {
+			l0f0, l0f1, l1f0, l1f1, l2f0, l2f1 = 0, 0, "", "", 0, 0
+			result = nil
+
+			err := Execute(t.Context(), cmd, WithArgs([]string{
+				"--l0f0", "255", "--l0f1=27",
+				"l1", "--l1f0", "254", "--l1f1=26",
+				"l2", "--l2f0=253", "000", "--l2f1", "25", "111", "--", "--l2f0=255",
+			}))
+
+			assert(t, nilerr(err))
+			assert(t, eq(255, l0f0))
+			assert(t, eq(27, l0f1))
+			assert(t, eq("254", l1f0))
+			assert(t, eq("26", l1f1))
+			assert(t, eq(253, l2f0))
+			assert(t, eq(0, l2f1))
+			assert(t, match([]string{"000", "--l2f1", "25", "111", "--", "--l2f0=255"}, result))
+		})
+	})
+}
+
+type result struct {
+	res bool
+	msg string
+}
+
+func assert(t *testing.T, res result) {
+	if !res.res {
+		t.Fatalf("expectation failed: %s", res.msg)
+	}
+}
+
+func eq[T comparable](expected, actual T) result {
+	return result{expected == actual, fmt.Sprintf("values not equal: expected %v but was %v", expected, actual)}
+}
+
+func nilerr(err error) result {
+	return result{err == nil, fmt.Sprintf("unexpected error: %v", err)}
+}
+
+func match[S ~[]E, E comparable](expected, actual S) result {
+	return result{slices.Equal(expected, actual), fmt.Sprintf("slices not equal: expected %v but was %v", expected, actual)}
+}

--- a/flags.go
+++ b/flags.go
@@ -2,6 +2,10 @@ package cmder
 
 import (
 	"flag"
+	"reflect"
+	"slices"
+
+	"github.com/brandon1024/cmder/getopt"
 )
 
 // FlagInitializer is an interface implemented by commands that need to register flags.
@@ -13,4 +17,51 @@ import (
 // to the [UsageOutputWriter].
 type FlagInitializer interface {
 	InitializeFlags(*flag.FlagSet)
+}
+
+// flagParser is an interface implemented by types that parse args.
+type flagParser interface {
+	Parse([]string) error
+	Args() []string
+}
+
+// areSame check if f1 and f2 have the same underlying [flag.Value].
+func areSame(f1, f2 flag.Value) bool {
+	var (
+		ref1 = reflect.ValueOf(f1)
+		ref2 = reflect.ValueOf(f2)
+	)
+
+	if ref1.Comparable() && ref2.Comparable() && f1 == f2 {
+		return true
+	}
+
+	if ref1.Kind() != ref2.Kind() {
+		return false
+	}
+
+	if !slices.Contains([]reflect.Kind{reflect.Map, reflect.Pointer, reflect.Func, reflect.Slice}, ref1.Kind()) {
+		return false
+	}
+
+	return ref1.Pointer() == ref2.Pointer()
+}
+
+// isHiddenFlag checks if the given flag is hidden.
+func isHiddenFlag(flg *flag.Flag) bool {
+	hf, ok := flg.Value.(getopt.HiddenFlag)
+	return ok && hf.IsHiddenFlag()
+}
+
+// boolFlag is a [flag.Value] that implements an additional method IsBoolFlag which indicates whether the flag accepts
+// arguments or not.
+type boolFlag interface {
+	flag.Value
+	IsBoolFlag() bool
+}
+
+// isBoolFlag checks if the given flag is a boolean flag.
+func isBoolFlag(flg *flag.Flag) bool {
+	hf, ok := flg.Value.(boolFlag)
+	return ok && hf.IsBoolFlag()
 }

--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ type ExecuteOptions struct {
 	nativeFlags   bool
 	bindEnv       bool
 	bindEnvPrefix string
+	interspersed  bool
 }
 
 // A single option passed to [Execute].
@@ -55,5 +56,19 @@ func WithPrefixedEnvironmentBinding(prefix string) ExecuteOption {
 	return func(ops *ExecuteOptions) {
 		ops.bindEnv = true
 		ops.bindEnvPrefix = prefix
+	}
+}
+
+// WithInterspersedArgs enables interspersed args parsing, allowing command-line arguments and flags to be mixed. When
+// interspersed arg parsing is enabled, the following is permitted:
+//
+//	git log origin/main -p
+//
+// When interspersed arg parsing is disabled, flags must always come before args:
+//
+//	git log -p origin/main
+func WithInterspersedArgs() ExecuteOption {
+	return func(ops *ExecuteOptions) {
+		ops.interspersed = true
 	}
 }

--- a/usage.go
+++ b/usage.go
@@ -6,13 +6,10 @@ import (
 	"flag"
 	"io"
 	"os"
-	"reflect"
 	"slices"
 	"strings"
 	"text/template"
 	"time"
-
-	"github.com/brandon1024/cmder/getopt"
 )
 
 // Text template for rendering command usage information in a format similar to that of the popular
@@ -177,27 +174,6 @@ func flags(cmd command) map[string][]*flag.Flag {
 	return groups
 }
 
-func areSame(f1, f2 flag.Value) bool {
-	var (
-		ref1 = reflect.ValueOf(f1)
-		ref2 = reflect.ValueOf(f2)
-	)
-
-	if ref1.Comparable() && ref2.Comparable() && f1 == f2 {
-		return true
-	}
-
-	if ref1.Kind() != ref2.Kind() {
-		return false
-	}
-
-	if !slices.Contains([]reflect.Kind{reflect.Map, reflect.Pointer, reflect.Func, reflect.Slice}, ref1.Kind()) {
-		return false
-	}
-
-	return ref1.Pointer() == ref2.Pointer()
-}
-
 // flagUsage dumps the flag usage as rendered by the flag library. See [flag.FlagSet.PrintDefaults].
 func flagUsage(cmd command) string {
 	out := cmd.fs.Output()
@@ -238,21 +214,4 @@ func unquote(flg *flag.Flag) []string {
 	}
 
 	return []string{name, usage}
-}
-
-// isHiddenFlag checks if the given flag is hidden.
-func isHiddenFlag(flg *flag.Flag) bool {
-	hf, ok := flg.Value.(getopt.HiddenFlag)
-	return ok && hf.IsHiddenFlag()
-}
-
-type boolFlag interface {
-	flag.Value
-	IsBoolFlag() bool
-}
-
-// isBoolFlag checks if the given flag is a boolean flag.
-func isBoolFlag(flg *flag.Flag) bool {
-	hf, ok := flg.Value.(boolFlag)
-	return ok && hf.IsBoolFlag()
 }


### PR DESCRIPTION
Introduce a new ExecuteOption [WithInterspersedArgs] which instructs exec to permit interspersal of flags and positional arguments. By default, interspersed parsing is disabled. Add a motivating example.

Make a few fixes and improvements.