### PR TITLE
fix: skip hidden subcommands inn rendered usage texts

### DIFF
--- a/command.go
+++ b/command.go
@@ -22,7 +22,7 @@ type Command interface {
 	// rendering usage and help texts.
 	Documented
 
-	// Name returns the name of this command.
+	// Name returns the name of this command or subcommand.
 	Name() string
 }
 
@@ -113,7 +113,10 @@ type Documented interface {
 
 	// ExampleText returns motivating usage examples for your command.
 	ExampleText() string
+}
 
+// HiddenCommand is implemented by commands which are not user facing. Hidden commands are not displayed in help texts.
+type HiddenCommand interface {
 	// Hidden returns a flag indicating whether to mark this command as hidden, preventing it from being rendered in
 	// help output.
 	Hidden() bool

--- a/example_lifecycle_test.go
+++ b/example_lifecycle_test.go
@@ -58,10 +58,6 @@ func (c *LifecycleCommand) ExampleText() string {
 	return LifecycleCommandExamples
 }
 
-func (c *LifecycleCommand) Hidden() bool {
-	return false
-}
-
 func ExampleRunnableLifecycle() {
 	args := []string{}
 

--- a/example_subcommands_test.go
+++ b/example_subcommands_test.go
@@ -81,10 +81,6 @@ func (c *ParentCommand) ExampleText() string {
 	return ParentCommandExamples
 }
 
-func (c *ParentCommand) Hidden() bool {
-	return false
-}
-
 func (c *ParentCommand) Subcommands() []cmder.Command {
 	return c.subcommands
 }
@@ -142,10 +138,6 @@ func (c *ChildCommand) HelpText() string {
 
 func (c *ChildCommand) ExampleText() string {
 	return ChildCommandExamples
-}
-
-func (c *ChildCommand) Hidden() bool {
-	return false
 }
 
 // === EXAMPLE ===

--- a/example_test.go
+++ b/example_test.go
@@ -48,10 +48,6 @@ func (c *HelloWorldCommand) ExampleText() string {
 	return HelloWorldCommandExamples
 }
 
-func (c *HelloWorldCommand) Hidden() bool {
-	return false
-}
-
 func ExampleCommand() {
 	args := []string{"from", "cmder"}
 	cmd := &HelloWorldCommand{}

--- a/examples/hello-world/child.go
+++ b/examples/hello-world/child.go
@@ -57,7 +57,3 @@ func (c *WorldCommand) HelpText() string {
 func (c *WorldCommand) ExampleText() string {
 	return WorldCommandExamples
 }
-
-func (c *WorldCommand) Hidden() bool {
-	return false
-}

--- a/examples/hello-world/parent.go
+++ b/examples/hello-world/parent.go
@@ -80,10 +80,6 @@ func (c *HelloCommand) ExampleText() string {
 	return HelloCommandExamples
 }
 
-func (c *HelloCommand) Hidden() bool {
-	return false
-}
-
 func (c *HelloCommand) Subcommands() []cmder.Command {
 	return c.subcommands
 }

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -90,7 +90,8 @@ func (c *ServerCommand) InitializeFlags(fs *flag.FlagSet) {
 
 func (c *ServerCommand) Initialize(ctx context.Context, args []string) error {
 	if len(args) != 0 {
-		return fmt.Errorf("too many arguments: %v", args)
+		fmt.Fprintf(os.Stderr, "error: too many arguments: %v\n", args)
+		return cmder.ErrShowUsage
 	}
 
 	if !c.noAuth && c.basicAuth == "" {
@@ -159,10 +160,6 @@ func (c *ServerCommand) HelpText() string {
 
 func (c *ServerCommand) ExampleText() string {
 	return ServerCommandExamples
-}
-
-func (c *ServerCommand) Hidden() bool {
-	return false
 }
 
 func main() {

--- a/execute_test.go
+++ b/execute_test.go
@@ -3,8 +3,6 @@ package cmder
 import (
 	"context"
 	"flag"
-	"fmt"
-	"slices"
 	"testing"
 )
 
@@ -88,27 +86,4 @@ func TestExecute(t *testing.T) {
 			assert(t, match([]string{"000", "--l2f1", "25", "111", "--", "--l2f0=255"}, result))
 		})
 	})
-}
-
-type result struct {
-	res bool
-	msg string
-}
-
-func assert(t *testing.T, res result) {
-	if !res.res {
-		t.Fatalf("expectation failed: %s", res.msg)
-	}
-}
-
-func eq[T comparable](expected, actual T) result {
-	return result{expected == actual, fmt.Sprintf("values not equal: expected %v but was %v", expected, actual)}
-}
-
-func nilerr(err error) result {
-	return result{err == nil, fmt.Sprintf("unexpected error: %v", err)}
-}
-
-func match[S ~[]E, E comparable](expected, actual S) result {
-	return result{slices.Equal(expected, actual), fmt.Sprintf("slices not equal: expected %v but was %v", expected, actual)}
 }

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -1,0 +1,36 @@
+package cmder
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+// result represents the result of an assertion. res is false if the assertion failed. msg is a descriptive message for
+// the failed assertion.
+type result struct {
+	res bool
+	msg string
+}
+
+// assert fails the test if assertion res failed.
+func assert(t *testing.T, res result) {
+	if !res.res {
+		t.Fatalf("expectation failed: %s", res.msg)
+	}
+}
+
+// eq asserts that the given values are equal (==).
+func eq[T comparable](expected, actual T) result {
+	return result{expected == actual, fmt.Sprintf("values not equal: expected %v but was %v", expected, actual)}
+}
+
+// nilerr asserts that the given error is nil.
+func nilerr(err error) result {
+	return result{err == nil, fmt.Sprintf("unexpected error: %v", err)}
+}
+
+// match asserts that the given slices have the same values.
+func match[S ~[]E, E comparable](expected, actual S) result {
+	return result{slices.Equal(expected, actual), fmt.Sprintf("slices not equal: expected %v but was %v", expected, actual)}
+}


### PR DESCRIPTION
The usage renderer failed to respect the hidden status on subcommands. This has been corrected. Additionally, [Hidden] has been removed from the Documented interface and given it's own interface, [HiddenCommand], since it's generally rare for subcommands to be hidden and adds unecessary bloat.

A few small fixes throughout the project.