### PR TITLE
chore(deps): upgrade toolchain to 1.26.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,4 +21,4 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.6
+        version: v2.9

--- a/README.md
+++ b/README.md
@@ -70,10 +70,12 @@ func run(ctx context.Context, args []string) error {
 func main() {
 	cmd := &cmder.BaseCommand{
 		CommandName: "hello-world",
-		Usage:       "hello-world [<args>...]",
-		ShortHelp:   "Simple demonstration of cmder",
-		Help:        HelloWorldHelpText,
-		Examples:    HelloWorldExamples,
+		CommandDocumentation: cmder.CommandDocumentation{
+			Usage:       "hello-world [<args>...]",
+			ShortHelp:   "Simple demonstration of cmder",
+			Help:        HelloWorldHelpText,
+			Examples:    HelloWorldExamples,
+		},
 		RunFunc:     run,
 	}
 
@@ -113,7 +115,7 @@ base-command --msg 'hi bob!'
 `
 
 type BaseCommandExample struct {
-	cmder.BaseCommand
+	cmder.CommandDocumentation
 
 	msg string
 }
@@ -128,10 +130,13 @@ func (c *BaseCommandExample) Run(ctx context.Context, args []string) error {
 	return nil
 }
 
+func (c *BaseCommandExample) Name() string {
+	return "base-command"
+}
+
 func main() {
 	cmd := &BaseCommandExample{
-		BaseCommand: cmder.BaseCommand{
-			CommandName: "base-command",
+		CommandDocumentation: cmder.CommandDocumentation{
 			Usage:       "base-command [-m | --msg <message>] [<args>...]",
 			ShortHelp:   "A simple example with struct embedding",
 			Help:        BaseCommandExampleHelpText,

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/brandon1024/cmder
 
 go 1.24.0
 
-toolchain go1.25.7
+toolchain go1.26.0
 
 tool (
 	golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Upgrade to the latest release of Go, 1.26.0. Fix the example in the project README.