### PR TITLE
chore: make usage template and writer configurable via exec options

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,5 +1,7 @@
 package cmder
 
+import "io"
+
 // ExecuteOptions configure the behaviour of [Execute].
 type ExecuteOptions struct {
 	args          []string
@@ -7,6 +9,8 @@ type ExecuteOptions struct {
 	bindEnv       bool
 	bindEnvPrefix string
 	interspersed  bool
+	usageTemplate string
+	usageWriter   io.Writer
 }
 
 // ExecuteOption is a single option passed to [Execute].
@@ -70,5 +74,24 @@ func WithPrefixedEnvironmentBinding(prefix string) ExecuteOption {
 func WithInterspersedArgs() ExecuteOption {
 	return func(ops *ExecuteOptions) {
 		ops.interspersed = true
+	}
+}
+
+// WithUsageTemplate is used to provide an alternate template for rendering command usage help text. The template is
+// rendered by the standard [text/template] package. This is particularly useful for applications which prefer to format
+// command usage information differently than the cmder defaults.
+//
+// By default, the [CobraUsageTemplate] template is used.
+func WithUsageTemplate(tmpl string) ExecuteOption {
+	return func(ops *ExecuteOptions) {
+		ops.usageTemplate = tmpl
+	}
+}
+
+// WithUsageOutput is used to provide an alternate [io.Writer] to write rendered command usage help text. By default,
+// [os.Stderr] is used.
+func WithUsageOutput(output io.Writer) ExecuteOption {
+	return func(ops *ExecuteOptions) {
+		ops.usageWriter = output
 	}
 }

--- a/usage.go
+++ b/usage.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"cmp"
 	"flag"
-	"io"
-	"os"
 	"slices"
 	"strings"
 	"text/template"
@@ -85,19 +83,12 @@ Examples:
 const StdFlagUsageTemplate = `usage: {{ .Command.UsageLine }}
 {{ flagusage . }}`
 
-// UsageTemplate is the text template for rendering command usage information.
-var UsageTemplate = CobraUsageTemplate
-
-// UsageOutputWriter is the default writer for command usage information. Standard error is recommended, but you can
-// override this if needed (particularly useful in tests).
-var UsageOutputWriter io.Writer = os.Stderr
-
-// ErrShowUsage instructs cmder to render usage and exit.
+// ErrShowUsage instructs cmder to render usage and exit (status 2).
 var ErrShowUsage = flag.ErrHelp
 
 // usage renders usage text for a [Command] using the default template [UsageTemplate]. Output is written to
 // [UsageOutputWriter].
-func usage(cmd command) error {
+func usage(cmd command, ops *ExecuteOptions) error {
 	tmpl, err := template.New("usage").Funcs(template.FuncMap{
 		"commands":  subcommands,
 		"flags":     flags,
@@ -111,12 +102,12 @@ func usage(cmd command) error {
 		"contains":  strings.Contains,
 		"trim":      strings.TrimSpace,
 		"lines":     strings.Lines,
-	}).Parse(UsageTemplate)
+	}).Parse(ops.usageTemplate)
 	if err != nil {
 		return err
 	}
 
-	return tmpl.Execute(UsageOutputWriter, cmd)
+	return tmpl.Execute(ops.usageWriter, cmd)
 }
 
 // subcommands returns a map of (visible) child subcommands for cmd.

--- a/usage_test.go
+++ b/usage_test.go
@@ -3,7 +3,6 @@ package cmder
 import (
 	"bytes"
 	"flag"
-	"os"
 	"testing"
 	"time"
 
@@ -169,18 +168,14 @@ func TestUsage(t *testing.T) {
 	cmd.fs.String("web.telemetry-path", "/metrics", "path under which to expose metrics")
 	cmd.fs.Bool("web.disable-exporter-metrics", false, "exclude metrics about the exporter itself (go_*)")
 
-	t.Cleanup(func() {
-		UsageOutputWriter = os.Stderr
-		UsageTemplate = CobraUsageTemplate
-	})
-
 	t.Run("CobraUsageTemplate", func(t *testing.T) {
 		t.Run("should render correctly", func(t *testing.T) {
 			var buf bytes.Buffer
-			UsageOutputWriter = &buf
-			UsageTemplate = CobraUsageTemplate
 
-			err := usage(cmd)
+			err := usage(cmd, &ExecuteOptions{
+				usageTemplate: CobraUsageTemplate,
+				usageWriter:   &buf,
+			})
 			assert(t, nilerr(err))
 
 			if diff := cmp.Diff(ExpectedCobraUsageTemplate, buf.String()); diff != "" {
@@ -201,10 +196,11 @@ func TestUsage(t *testing.T) {
 			})
 
 			var buf bytes.Buffer
-			UsageOutputWriter = &buf
-			UsageTemplate = CobraUsageTemplate
 
-			err := usage(cmd)
+			err := usage(cmd, &ExecuteOptions{
+				usageTemplate: CobraUsageTemplate,
+				usageWriter:   &buf,
+			})
 			assert(t, nilerr(err))
 
 			if diff := cmp.Diff(ExpectedCobraUsageTemplate, buf.String()); diff != "" {
@@ -216,10 +212,11 @@ func TestUsage(t *testing.T) {
 	t.Run("StdFlagUsageTemplate", func(t *testing.T) {
 		t.Run("should render correctly", func(t *testing.T) {
 			var buf bytes.Buffer
-			UsageOutputWriter = &buf
-			UsageTemplate = StdFlagUsageTemplate
 
-			err := usage(cmd)
+			err := usage(cmd, &ExecuteOptions{
+				usageTemplate: StdFlagUsageTemplate,
+				usageWriter:   &buf,
+			})
 			assert(t, nilerr(err))
 
 			if diff := cmp.Diff(ExpectedStdFlagUsageTemplate, buf.String()); diff != "" {


### PR DESCRIPTION
Drop the package variables for configuring the usage render template and output writer. Instead, make this configurable via exec options avoid avoid package statefulness.