### PR TITLE
chore: split up runnable lifecycle and add getopt alias util

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,10 @@ are relevant for your command:
 
 - `Command`: All commands and subcommands must implement this interface.
 - `FlagInitializer`: If your command has flags, implement this interface.
-- `RunnableLifecycle`: If your command needs some initialization or teardown,
-  implement this interface.
+- `Initializer`: If your command needs some initialization, implement this
+  interface.
+- `Destroyer`: If your command needs some teardown, implement this
+  interface.
 
 For more information, read through our package documentation on
 [pkg.go.dev](https://pkg.go.dev/github.com/brandon1024/cmder).

--- a/example_basecommand_embed_test.go
+++ b/example_basecommand_embed_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/brandon1024/cmder"
+	"github.com/brandon1024/cmder/getopt"
 )
 
 // This example demonstrates an alternative usage of [cmder.BaseCommand]. By embedding BaseCommand into your own types,
@@ -69,11 +70,11 @@ func (s *Semver) InitializeFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.pre, "pre-release", s.pre, "include pre-release information in output (e.g. alpha, x.7.z.92)")
 	fs.StringVar(&s.build, "build", s.build, "include build information in output (e.g. 20130313144700, exp.sha.5114f85)")
 
-	fs.Var(alias(fs.Lookup("major"), "M"))
-	fs.Var(alias(fs.Lookup("minor"), "m"))
-	fs.Var(alias(fs.Lookup("patch"), "p"))
-	fs.Var(alias(fs.Lookup("pre-release"), "x"))
-	fs.Var(alias(fs.Lookup("build"), "b"))
+	getopt.Alias(fs, "major", "M")
+	getopt.Alias(fs, "minor", "m")
+	getopt.Alias(fs, "patch", "p")
+	getopt.Alias(fs, "pre-release", "x")
+	getopt.Alias(fs, "build", "b")
 }
 
 // The command's run function.
@@ -129,9 +130,4 @@ func (s *Semver) Run(ctx context.Context, args []string) error {
 	fmt.Println(version)
 
 	return nil
-}
-
-// Simple helper for creating flag aliases.
-func alias(flg *flag.Flag, name string) (flag.Value, string, string) {
-	return flg.Value, name, flg.Usage
 }

--- a/example_lifecycle_test.go
+++ b/example_lifecycle_test.go
@@ -7,7 +7,21 @@ import (
 	"github.com/brandon1024/cmder"
 )
 
-func ExampleRunnableLifecycle() {
+func ExampleInitializer() {
+	args := []string{}
+
+	cmd := &LifecycleCommand{}
+
+	if err := cmder.Execute(context.Background(), cmd, cmder.WithArgs(args)); err != nil {
+		fmt.Printf("unexpected error occurred: %v", err)
+	}
+	// Output:
+	// lifecycle: initializing
+	// lifecycle: running
+	// lifecycle: shutting down
+}
+
+func ExampleDestroyer() {
 	args := []string{}
 
 	cmd := &LifecycleCommand{}
@@ -26,7 +40,7 @@ const LifecycleCommandUsageLine = `lifecycle [<args>...]`
 const LifecycleCommandShortHelpText = `Example command with lifecycle routines`
 
 const LifecycleCommandHelpText = `
-'lifecycle' demonstrates a command that implements the RunnableLifecycle interface, defining initialization and
+'lifecycle' demonstrates a command that implements the Initializer and Destroyer interfaces, defining initialization and
 destroy routines.
 `
 

--- a/execute.go
+++ b/execute.go
@@ -24,17 +24,17 @@ var ErrEnvironmentBindFailure = errors.New("cmder: failed to update flag from en
 // # Execution Lifecycle
 //
 // When executing a command, Execute will call the [Runnable] Run() routine of your command. If the command also
-// implements [RunnableLifecycle], the [RunnableLifecycle] Initialize() and Destroy() routines will be invoked before
+// implements [Initializer] or [Destroyer], the Initialize() or Destroy() routines will be invoked before
 // and after calling Run().
 //
-// If the command implements [RootCommand] and a subcommand is invoked, Execute will invoke the [RunnableLifecycle]
-// routines of parent and child commands:
+// If the command implements [RootCommand] and a subcommand is invoked, Execute will invoke the [Initializer] and
+// [Destroyer] routines of parent and child commands:
 //
-//  1. Root  [RunnableLifecycle] Initialize()
-//  2. Child [RunnableLifecycle] Initialize()
+//  1. Root  [Initializer] Initialize()
+//  2. Child [Initializer] Initialize()
 //  3. Child [Runnable] Run()
-//  4. Child [RunnableLifecycle] Destroy()
-//  5. Root  [RunnableLifecycle] Destroy()
+//  4. Child [Destroyer] Destroy()
+//  5. Root  [Destroyer] Destroy()
 //
 // If a command implements [RootCommand] but the first argument passed to the command doesn't match a recognized child
 // command Name(), the Run() routine will be executed.
@@ -153,11 +153,11 @@ type command struct {
 	showHelp bool
 }
 
-// onInit calls the [RunnableLifecycle] init routine if present on c.
+// onInit calls the [Initializer] init routine if present on c.
 func (c command) onInit(ctx context.Context, ops *ExecuteOptions) error {
 	var err error
 
-	if cmd, ok := c.Command.(RunnableLifecycle); ok {
+	if cmd, ok := c.Command.(Initializer); ok {
 		err = cmd.Initialize(ctx, c.args)
 	}
 
@@ -180,11 +180,11 @@ func (c command) run(ctx context.Context, ops *ExecuteOptions) error {
 	return err
 }
 
-// onDestroy calls the [RunnableLifecycle] destroy routine if present on c.
+// onDestroy calls the [Destroyer] destroy routine if present on c.
 func (c command) onDestroy(ctx context.Context, ops *ExecuteOptions) error {
 	var err error
 
-	if cmd, ok := c.Command.(RunnableLifecycle); ok {
+	if cmd, ok := c.Command.(Destroyer); ok {
 		err = cmd.Destroy(ctx, c.args)
 	}
 

--- a/getopt/alias.go
+++ b/getopt/alias.go
@@ -1,0 +1,19 @@
+package getopt
+
+import (
+	"flag"
+	"fmt"
+)
+
+// Alias is a simply utility for registering flag aliases, registering a new flag in fs with name alias with the
+// [flag.Value] of a flag named name.
+//
+// If flag name doesn't exist in fs, panic.
+func Alias(fs *flag.FlagSet, name, alias string) {
+	flg := fs.Lookup(name)
+	if flg == nil {
+		panic(fmt.Sprintf("cmder: cannot register alias '%s: target '%s' does not exist in flag set'", alias, name))
+	}
+
+	fs.Var(flg.Value, alias, flg.Usage)
+}

--- a/getopt/alias_test.go
+++ b/getopt/alias_test.go
@@ -1,0 +1,34 @@
+package getopt
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestAlias(t *testing.T) {
+	t.Run("should panic if target flag does not exist", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("no panic")
+			}
+		}()
+
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		Alias(fs, "non-existent", "q")
+	})
+
+	t.Run("should register alias successfully", func(t *testing.T) {
+		var quiet bool
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.BoolVar(&quiet, "quiet", quiet, "silence the cat")
+
+		Alias(fs, "quiet", "q")
+
+		if err := fs.Parse([]string{"-q", "true"}); err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+		if !quiet {
+			t.Fatalf("alias not triggered")
+		}
+	})
+}


### PR DESCRIPTION
This revision splits up the RunnableLifecycle interface into two, Initializer and Destroyer, since it's often the case that commands need initialization but not teardown.

Additionally, add a new getopt.Alias util for easily registering flag aliases.