### PR TITLE
chore: do not call os exit on usage to allow for resource cleaup

### DIFF
--- a/execute_test.go
+++ b/execute_test.go
@@ -2,8 +2,13 @@ package cmder
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"net/http"
 	"testing"
+	"time"
+
+	"github.com/brandon1024/cmder/getopt"
 )
 
 func TestExecute(t *testing.T) {
@@ -84,6 +89,95 @@ func TestExecute(t *testing.T) {
 			assert(t, eq(253, l2f0))
 			assert(t, eq(0, l2f1))
 			assert(t, match([]string{"000", "--l2f1", "25", "111", "--", "--l2f0=255"}, result))
+		})
+	})
+
+	t.Run("native flags", func(t *testing.T) {
+		var (
+			addr           string
+			readTimeout    time.Duration
+			writeTimeout   time.Duration
+			maxHeaderBytes int
+			maxBodySize    int64
+			basicAuth      string
+			noAuth         bool
+		)
+
+		var args []string
+
+		cmd := &BaseCommand{
+			CommandName: "native-flags",
+			InitFlagsFunc: func(fs *flag.FlagSet) {
+				fs.StringVar(&addr, "http.bind-addr", ":8080", "bind address for the web server")
+				fs.DurationVar(&readTimeout, "http.read-timeout", time.Duration(0), "read timeout for requests")
+				fs.DurationVar(&writeTimeout, "http.write-timeout", time.Duration(0), "write timeout for responses")
+				fs.IntVar(&maxHeaderBytes, "http.max-header-size", http.DefaultMaxHeaderBytes, "max permitted size of the headers in a request")
+				fs.Int64Var(&maxBodySize, "http.max-body-size", 1<<26, "max permitted size of the headers in a request")
+				fs.StringVar(&basicAuth, "http.auth-basic", "", "basic auth credentials (in format user:pass)")
+				fs.BoolVar(&noAuth, "http.no-auth", false, "disable basic auth")
+
+				getopt.Alias(fs, "http.bind-addr", "a")
+				getopt.Alias(fs, "http.read-timeout", "r")
+				getopt.Alias(fs, "http.write-timeout", "w")
+				getopt.Alias(fs, "http.max-header-size", "h")
+				getopt.Alias(fs, "http.max-body-size", "b")
+				getopt.Alias(fs, "http.auth-basic", "C")
+				getopt.Alias(fs, "http.no-auth", "E")
+			},
+			RunFunc: func(ctx context.Context, a []string) error {
+				args = a
+				return nil
+			},
+		}
+
+		t.Run("should correctly parse flags in standard flag libs format", func(t *testing.T) {
+			err := Execute(t.Context(), cmd, WithNativeFlags(), WithArgs([]string{
+				"-http.bind-addr", "0.0.0.0:8000",
+				"--http.read-timeout", "10s",
+				"-http.write-timeout=5s",
+				"-h", "8096",
+				"-b=65536",
+				"-http.auth-basic", "U:P",
+				"--",
+				"-http.no-auth", "true",
+			}))
+
+			assert(t, nilerr(err))
+			assert(t, eq("0.0.0.0:8000", addr))
+			assert(t, eq(10*time.Second, readTimeout))
+			assert(t, eq(5*time.Second, writeTimeout))
+			assert(t, eq(8096, maxHeaderBytes))
+			assert(t, eq(65536, maxBodySize))
+			assert(t, eq("U:P", basicAuth))
+			assert(t, eq(false, noAuth))
+			assert(t, match([]string{"-http.no-auth", "true"}, args))
+		})
+	})
+
+	t.Run("help flags", func(t *testing.T) {
+		t.Run("should not register help flags if defined by command", func(t *testing.T) {
+			var showHelp bool
+
+			cmd := &BaseCommand{
+				CommandName: "help-cmd",
+				InitFlagsFunc: func(fs *flag.FlagSet) {
+					fs.BoolVar(&showHelp, "h", showHelp, "show help")
+					fs.BoolVar(&showHelp, "help", showHelp, "show help")
+				},
+			}
+
+			err := Execute(t.Context(), cmd, WithArgs([]string{"--help"}))
+			assert(t, nilerr(err))
+			assert(t, eq(true, showHelp))
+		})
+
+		t.Run("should return ErrShowUsage if help flags not defined", func(t *testing.T) {
+			cmd := &BaseCommand{
+				CommandName: "help-cmd",
+			}
+
+			err := Execute(t.Context(), cmd, WithArgs([]string{"--help"}))
+			assert(t, eq(true, errors.Is(err, ErrShowUsage)))
 		})
 	})
 }


### PR DESCRIPTION
Calling os.Exit from a library can be problematic for some users, especially when cleanup is necessary. Whenever usage is rendered, return error ErrShowUsage and let the caller handle it appropriately.

Add tests.