### PR TITLE
chore: render usage and help texts differently

### DIFF
--- a/example_exec_option_bind_env_test.go
+++ b/example_exec_option_bind_env_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func ExampleWithEnvironmentBinding() {
-	_ = os.Setenv("BINDENV_SHOW_FORMAT", "overidden-by-flag")
-	_ = os.Setenv("BINDENV_SHOW_PAGECOUNT", "20")
+	os.Setenv("BINDENV_SHOW_FORMAT", "overidden-by-flag")
+	os.Setenv("BINDENV_SHOW_PAGECOUNT", "20")
 
 	args := []string{"show", "--format=pretty"}
 

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -23,7 +23,7 @@ func main() {
 	err := cmder.Execute(ctx, &ServerCommand{})
 	cancel()
 
-	if err != nil {
+	if err != nil && !errors.Is(err, cmder.ErrShowUsage) && !errors.Is(err, cmder.ErrShowUsage) {
 		fmt.Printf("unexpected error occurred: %v\n", err)
 		os.Exit(1)
 	}
@@ -91,13 +91,20 @@ type ServerCommand struct {
 }
 
 func (c *ServerCommand) InitializeFlags(fs *flag.FlagSet) {
-	fs.StringVar(&c.addr, "http.bind-addr", ":8080", "bind address for the web server")
-	fs.DurationVar(&c.readTimeout, "http.read-timeout", time.Duration(0), "read timeout for requests")
-	fs.DurationVar(&c.writeTimeout, "http.write-timeout", time.Duration(0), "write timeout for responses")
-	fs.IntVar(&c.maxHeaderBytes, "http.max-header-size", http.DefaultMaxHeaderBytes, "max permitted size of the headers in a request")
-	fs.Int64Var(&c.maxBodySize, "http.max-body-size", 1<<26, "max permitted size of the headers in a request")
-	fs.StringVar(&c.basicAuth, "http.auth-basic", "", "basic auth credentials (in format user:pass)")
-	fs.BoolVar(&c.noAuth, "http.no-auth", false, "disable basic auth")
+	fs.StringVar(&c.addr, "http.bind-addr", ":8080",
+		"Sets the `address:port` on which the server will accept requests. The address may be an IPv4 (e.g. 127.0.0.1) or IPv6 (e.g. [2001:db8::1]) address. The address may be empty, in which case the local system is implied (0.0.0.0). If the port is empty or '0' (e.g. ':0'), a port number is automatically chosen.")
+	fs.DurationVar(&c.readTimeout, "http.read-timeout", time.Duration(0),
+		"Configures the maximum duration for reading the entire request, including the body (e.g. 10s). Negative or zero (e.g. 0s) disables the timeout.")
+	fs.DurationVar(&c.writeTimeout, "http.write-timeout", time.Duration(0),
+		"Configures the maximum duration for writing a client response. Negative or zero (e.g. 0s) disables the timeout.")
+	fs.IntVar(&c.maxHeaderBytes, "http.max-header-size", http.DefaultMaxHeaderBytes,
+		"Set the maximum header size, in bytes. Negative or zero disables the limit.")
+	fs.Int64Var(&c.maxBodySize, "http.max-body-size", 1<<26,
+		"Set the maximum request body size, in bytes. Negative or zero disables the limit.")
+	fs.StringVar(&c.basicAuth, "http.auth-basic", "",
+		"Configure basic auth credentials with format `user:pass`.")
+	fs.BoolVar(&c.noAuth, "http.no-auth", false,
+		"Disable basic auth, making the server available to all.")
 }
 
 func (c *ServerCommand) Initialize(ctx context.Context, args []string) error {

--- a/execute.go
+++ b/execute.go
@@ -70,13 +70,13 @@ var ErrEnvironmentBindFailure = errors.New("cmder: failed to update flag from en
 //
 // # Usage and Help Texts
 //
-// Whenever the user provides the '-h' or '--help' flag at the command line and the command doesn't register custom help
-// flags, Execute will display command usage and return [ErrShowUsage]. The format of the help text can be adjusted with
-// [WithUsageTemplate]. By default, usage information will be written to stderr, but this can be adjusted by setting
-// [WithUsageOutput].
+// Unless explicitly overridden by the command, the '-h' flag instructs Execute to render command usage information to
+// stdout and return [ErrShowUsage]. The default usage text includes a usage synopsis, subcommands and flags. The
+// format of the usage text can be adjusted (see [WithUsageTemplate]). Returning [ErrShowUsage] from a command's
+// Initialize or Run routines will also instruct Execute to render usage.
 //
-// If a command's Run routine returns [ErrShowUsage] (or an error wrapping [ErrShowUsage]), Execute will render
-// help text and return the error.
+// Likewise, the '--help' flag instructs Execute to render extended help usage information to stdout, returning
+// [ErrShowHelp]. The format may be adjusted (see [WithHelpTemplate]).
 func Execute(ctx context.Context, cmd Command, op ...ExecuteOption) error {
 	// do some checks
 	if cmd == nil {
@@ -86,8 +86,9 @@ func Execute(ctx context.Context, cmd Command, op ...ExecuteOption) error {
 	// prepare executor options
 	ops := &ExecuteOptions{
 		args:          os.Args[1:],
-		usageTemplate: CobraUsageTemplate,
-		usageWriter:   os.Stderr,
+		usageTemplate: DefaultUsageTemplate,
+		helpTemplate:  DefaultHelpTemplate,
+		outputWriter:  os.Stdout,
 	}
 	for _, f := range op {
 		f(ops)
@@ -144,17 +145,21 @@ func execute(ctx context.Context, stack []command, ops *ExecuteOptions) error {
 type command struct {
 	Command
 
-	fs       *flag.FlagSet
-	args     []string
-	showHelp bool
+	fs        *flag.FlagSet
+	args      []string
+	showUsage bool
+	showHelp  bool
 }
 
 // onInit calls the [Initializer] init routine if present on c.
 func (c command) onInit(ctx context.Context, ops *ExecuteOptions) error {
 	var err error
 
-	if c.showHelp {
+	if c.showUsage {
 		return errors.Join(ErrShowUsage, usage(c, ops))
+	}
+	if c.showHelp {
+		return errors.Join(ErrShowUsage, help(c, ops))
 	}
 
 	if cmd, ok := c.Command.(Initializer); ok {
@@ -170,6 +175,13 @@ func (c command) onInit(ctx context.Context, ops *ExecuteOptions) error {
 
 // run calls the [Runnable] run routine of c.
 func (c command) run(ctx context.Context, ops *ExecuteOptions) error {
+	if c.showUsage {
+		return errors.Join(ErrShowUsage, usage(c, ops))
+	}
+	if c.showHelp {
+		return errors.Join(ErrShowUsage, help(c, ops))
+	}
+
 	err := c.Run(ctx, c.args)
 	if errors.Is(err, ErrShowUsage) {
 		return errors.Join(err, usage(c, ops))
@@ -214,9 +226,11 @@ func buildCallStack(cmd Command, ops *ExecuteOptions) ([]command, error) {
 		}
 
 		// add help flags
-		if this.fs.Lookup("h") == nil && this.fs.Lookup("help") == nil {
-			this.fs.BoolVar(&this.showHelp, "h", false, "show command help and usage information")
-			this.fs.BoolVar(&this.showHelp, "help", false, "show command help and usage information")
+		if this.fs.Lookup("h") == nil {
+			this.fs.BoolVar(&this.showUsage, "h", false, "show command usage information")
+		}
+		if this.fs.Lookup("help") == nil {
+			this.fs.BoolVar(&this.showHelp, "help", false, "show command help information")
 		}
 
 		// bind environment variables

--- a/flags.go
+++ b/flags.go
@@ -8,12 +8,12 @@ import (
 	"github.com/brandon1024/cmder/getopt"
 )
 
-// FlagInitializer is an interface implemented by commands that need to register flags.
+// FlagInitializer is an interface implemented by a [Command] that need to register flags.
 //
-// InitializeFlags will be invoked during [Execute], prior to Initialize/Run/Destroy routines. You can use this to
+// InitializeFlags will be invoked during [Execute], prior to Initialize()/Run()/Destroy() routines. You can use this to
 // register flags for your command.
 //
-// If the command does not define help flags '-h' and '--help', they will be registered automatically and will instruct
+// If the command does not define help flags '-h' or '--help', they will be registered automatically and will instruct
 // [Execute] to render command usage.
 type FlagInitializer interface {
 	InitializeFlags(*flag.FlagSet)

--- a/getopt/example_mapvar_test.go
+++ b/getopt/example_mapvar_test.go
@@ -12,16 +12,20 @@ import (
 // This example demonstrates usage of [getopt.MapVar] for string maps. You'll often find map flags on commands that
 // perform templating of text files, for example.
 func ExampleMapVar() {
-	variables := getopt.MapVar{}
-
 	fs := flag.NewFlagSet("map", flag.ContinueOnError)
+
+	// option 1: use MapVar directly
+	variables := getopt.MapVar{}
 	fs.Var(&variables, "variable", "specify runtime variables")
-	fs.Var(&variables, "v", "specify runtime variables")
+
+	// option 2: wrap an existing map with Map
+	arg := map[string]string{}
+	fs.Var(getopt.Map(arg), "arg", "specify runtime args")
 
 	args := []string{
 		"--variable", "key1=value1",
-		"-v", "key2=value2,key3=value3",
-		`--variable="hello= HI, WORLD "`,
+		"--variable", "key2=value2,key3=value3",
+		`--arg="hello= HI, WORLD "`,
 	}
 
 	if err := fs.Parse(args); err != nil {
@@ -31,9 +35,12 @@ func ExampleMapVar() {
 	for _, k := range slices.Sorted(maps.Keys(variables)) {
 		fmt.Printf("%s: '%s'\n", k, variables[k])
 	}
+	for _, k := range slices.Sorted(maps.Keys(arg)) {
+		fmt.Printf("%s: '%s'\n", k, arg[k])
+	}
 	// Output:
-	// hello: ' HI, WORLD '
 	// key1: 'value1'
 	// key2: 'value2'
 	// key3: 'value3'
+	// hello: ' HI, WORLD '
 }

--- a/getopt/example_stringsvar_test.go
+++ b/getopt/example_stringsvar_test.go
@@ -16,14 +16,19 @@ func ExampleStringsVar() {
 	var hosts getopt.StringsVar
 	fs.Var(&hosts, "broker", "connect to a broker")
 
-	// option 2: wrap an existing slice
+	// option 2: wrap an existing slice with Strings
 	var args []string
-	fs.Var((*getopt.StringsVar)(&args), "a", "provide args")
+	fs.Var(getopt.Strings(&args), "a", "provide args")
+
+	// option 3: wrap an existing slice by pointer casting
+	var patterns []string
+	fs.Var((*getopt.StringsVar)(&patterns), "p", "provide patterns")
 
 	fs.Parse([]string{
 		"--broker", "tls://broker-1.domain.example.com,tls://broker-2.domain.example.com",
 		"-a", "CLIENT_USER",
 		"-a", "CLIENT_PASS",
+		"-p", "**/*.go,*.mod,*.sum",
 	})
 
 	for _, host := range hosts {
@@ -32,9 +37,15 @@ func ExampleStringsVar() {
 	for _, arg := range args {
 		fmt.Printf("arg: '%s'\n", arg)
 	}
+	for _, patt := range patterns {
+		fmt.Printf("patterns: '%s'\n", patt)
+	}
 	// Output:
 	// broker: 'tls://broker-1.domain.example.com'
 	// broker: 'tls://broker-2.domain.example.com'
 	// arg: 'CLIENT_USER'
 	// arg: 'CLIENT_PASS'
+	// patterns: '**/*.go'
+	// patterns: '*.mod'
+	// patterns: '*.sum'
 }

--- a/getopt/example_timevar_test.go
+++ b/getopt/example_timevar_test.go
@@ -3,19 +3,26 @@ package getopt_test
 import (
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/brandon1024/cmder/getopt"
 )
 
 // This example demonstrates the usage of [getopt.TimeVar].
 func ExampleTimeVar() {
-	var since getopt.TimeVar
-
 	fs := flag.NewFlagSet("custom", flag.ContinueOnError)
+
+	// option 1: using TimeVar directly
+	var since getopt.TimeVar
 	fs.Var(&since, "since", "show items since")
+
+	// option 2: with Time
+	var until time.Time
+	fs.Var(getopt.Time(&until), "until", "show items until")
 
 	args := []string{
 		"-since", "2025-01-01T00:00:00Z",
+		"-until", "2026-01-01T00:00:00Z",
 	}
 
 	if err := fs.Parse(args); err != nil {
@@ -23,6 +30,8 @@ func ExampleTimeVar() {
 	}
 
 	fmt.Printf("since: %s\n", since.String())
+	fmt.Printf("until: %s\n", until.String())
 	// Output:
 	// since: 2025-01-01T00:00:00Z
+	// until: 2026-01-01 00:00:00 +0000 UTC
 }

--- a/getopt/mapvar.go
+++ b/getopt/mapvar.go
@@ -20,6 +20,11 @@ import (
 //	key1=v=1,key2=v=2
 type MapVar map[string]string
 
+// Map returns a [MapVar] for ss.
+func Map(m map[string]string) MapVar {
+	return MapVar(m)
+}
+
 // String returns the map, formatted as a set of key-value pairs.
 func (m MapVar) String() string {
 	var entries []string

--- a/getopt/stringsvar.go
+++ b/getopt/stringsvar.go
@@ -17,6 +17,11 @@ import (
 //	"value, 1","value, 2"
 type StringsVar []string
 
+// Strings returns a [StringsVar] for ss.
+func Strings(ss *[]string) *StringsVar {
+	return (*StringsVar)(ss)
+}
+
 // String returns the slice, formatted as comma-separated values.
 func (s StringsVar) String() string {
 	var builder strings.Builder

--- a/getopt/timevar.go
+++ b/getopt/timevar.go
@@ -8,6 +8,11 @@ import (
 // [flag.Getter].
 type TimeVar time.Time
 
+// Time returns a [TimeVar] for tm.
+func Time(tm *time.Time) *TimeVar {
+	return (*TimeVar)(tm)
+}
+
 // String returns the [time.RFC3339] representation of the timestamp flag.
 func (t *TimeVar) String() string {
 	return time.Time(*t).Format(time.RFC3339)

--- a/options.go
+++ b/options.go
@@ -9,8 +9,10 @@ type ExecuteOptions struct {
 	bindEnv       bool
 	bindEnvPrefix string
 	interspersed  bool
+
 	usageTemplate string
-	usageWriter   io.Writer
+	helpTemplate  string
+	outputWriter  io.Writer
 }
 
 // ExecuteOption is a single option passed to [Execute].
@@ -44,6 +46,8 @@ func WithNativeFlags() ExecuteOption {
 //
 //	git log --format=oneline   ->   GIT_LOG_FORMAT=oneline
 //	git log --no-abbrev-commit ->   GIT_LOG_NOABBREVCOMMIT=true
+//
+// See also [WithPrefixedEnvironmentBinding].
 func WithEnvironmentBinding() ExecuteOption {
 	return func(ops *ExecuteOptions) {
 		ops.bindEnv = true
@@ -56,6 +60,8 @@ func WithEnvironmentBinding() ExecuteOption {
 //	<PREFIX>COMMAND_FLAGNAME
 //	<PREFIX>COMMAND_SUBCOMMAND_FLAGNAME
 //	<PREFIX>COMMAND_SUBCOMMAND_SUBCOMMAND_FLAGNAME
+//
+// See also [WithEnvironmentBinding].
 func WithPrefixedEnvironmentBinding(prefix string) ExecuteOption {
 	return func(ops *ExecuteOptions) {
 		ops.bindEnv = true
@@ -77,21 +83,38 @@ func WithInterspersedArgs() ExecuteOption {
 	}
 }
 
-// WithUsageTemplate is used to provide an alternate template for rendering command usage help text. The template is
+// WithHelpTemplate is used to provide an alternate template for rendering command help text. The template is
+// rendered by the standard [text/template] package. This is particularly useful for applications which prefer to format
+// command help text differently than the cmder defaults.
+//
+// By default, the [DefaultHelpTemplate] template is used.
+//
+// See also [WithUsageTemplate] and [WithOutputWriter].
+func WithHelpTemplate(tmpl string) ExecuteOption {
+	return func(ops *ExecuteOptions) {
+		ops.helpTemplate = tmpl
+	}
+}
+
+// WithUsageTemplate is used to provide an alternate template for rendering command usage text. The template is
 // rendered by the standard [text/template] package. This is particularly useful for applications which prefer to format
 // command usage information differently than the cmder defaults.
 //
-// By default, the [CobraUsageTemplate] template is used.
+// By default, the [DefaultUsageTemplate] template is used.
+//
+// See also [WithHelpTemplate] and [WithOutputWriter].
 func WithUsageTemplate(tmpl string) ExecuteOption {
 	return func(ops *ExecuteOptions) {
 		ops.usageTemplate = tmpl
 	}
 }
 
-// WithUsageOutput is used to provide an alternate [io.Writer] to write rendered command usage help text. By default,
-// [os.Stderr] is used.
-func WithUsageOutput(output io.Writer) ExecuteOption {
+// WithOutputWriter is used to provide an alternate [io.Writer] to write rendered command usage/help text. By default,
+// [os.Stdout] is used.
+//
+// See also [WithHelpTemplate] and [WithUsageTemplate].
+func WithOutputWriter(output io.Writer) ExecuteOption {
 	return func(ops *ExecuteOptions) {
-		ops.usageWriter = output
+		ops.outputWriter = output
 	}
 }

--- a/usage.go
+++ b/usage.go
@@ -3,6 +3,7 @@ package cmder
 import (
 	"bytes"
 	"cmp"
+	"errors"
 	"flag"
 	"slices"
 	"strings"
@@ -10,11 +11,11 @@ import (
 	"time"
 )
 
-// CobraUsageTemplate is a text template for rendering command usage information in a format similar to that of the
-// popular [github.com/spf13/cobra] library.
-const CobraUsageTemplate = `{{ trim .Command.HelpText }}
+// DefaultHelpTemplate is a text template for rendering extended command help information.
+const DefaultHelpTemplate = `{{ trim .Command.HelpText }}{{ println }}{{ println }}` + DefaultUsageTemplate
 
-Usage:
+// DefaultUsageTemplate is a text template for rendering command usage information.
+const DefaultUsageTemplate = `Usage:
   {{ trim .Command.UsageLine }}
 
 Examples:
@@ -78,18 +79,50 @@ Examples:
 	{{- printf "Use \"%s [command] --help\" for more information about a command.\n" .Command.Name -}}
 {{- end -}}`
 
-// StdFlagUsageTemplate is a text template for rendering command usage information in a minimal format similar to that
-// of the [flag] library.
-const StdFlagUsageTemplate = `usage: {{ .Command.UsageLine }}
-{{ flagusage . }}`
+// ErrShowUsage instructs cmder to render usage.
+var ErrShowUsage = errors.New("cmder: usage requested")
 
-// ErrShowUsage instructs cmder to render usage and exit (status 2).
-var ErrShowUsage = flag.ErrHelp
+// ErrShowHelp instructs cmder to render help.
+var ErrShowHelp = errors.New("cmder: help requested")
 
-// usage renders usage text for a [Command] using the default template [UsageTemplate]. Output is written to
-// [UsageOutputWriter].
+// usage renders usage text for a [Command].
 func usage(cmd command, ops *ExecuteOptions) error {
-	tmpl, err := template.New("usage").Funcs(template.FuncMap{
+	tmpl, err := template.New("usage").Funcs(funcs()).Parse(ops.usageTemplate)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(ops.outputWriter, cmd)
+}
+
+// help renders extended help text for a [Command].
+func help(cmd command, ops *ExecuteOptions) error {
+	tmpl, err := template.New("help").Funcs(funcs()).Parse(ops.helpTemplate)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(ops.outputWriter, cmd)
+}
+
+// funcs returns template functions which can be used in usage/help text templates.
+//
+// The following template functions are available:
+//
+//   - commands(c):            Collect all subcommands of c into a map, keyed by name.
+//   - flags(c):               Collect all flags of c, organized by flag group name.
+//   - flagusage(c):           Return the flag usage of the flag set for c, as returned by PrintDefaults.
+//   - unquote(f):             Call UnquoteUsage on flag f.
+//   - lower(str):             Return string argument in lowercase.
+//   - upper(str):             Return string argument in uppercase.
+//   - split(str):             Split a string.
+//   - replace(str, old, new): Replace occurrences of a string.
+//   - join(slice, delim):     Join a list of strings.
+//   - contains(str, other):   Check if a string contains another string
+//   - trim(str):              Trim all leading and trailing whitespace of str.
+//   - lines(str):             Split str into a slice of text lines.
+func funcs() template.FuncMap {
+	return template.FuncMap{
 		"commands":  subcommands,
 		"flags":     flags,
 		"flagusage": flagUsage,
@@ -102,12 +135,7 @@ func usage(cmd command, ops *ExecuteOptions) error {
 		"contains":  strings.Contains,
 		"trim":      strings.TrimSpace,
 		"lines":     strings.Lines,
-	}).Parse(ops.usageTemplate)
-	if err != nil {
-		return err
 	}
-
-	return tmpl.Execute(ops.usageWriter, cmd)
 }
 
 // subcommands returns a map of (visible) child subcommands for cmd.

--- a/usage_test.go
+++ b/usage_test.go
@@ -31,7 +31,7 @@ test --log.level <level>
 test --poll-interval <sec> --web.disable-exporter-metrics
 `
 
-const ExpectedCobraUsageTemplate = `cmder - build powerful command-line applications in Go
+const ExpectedDefaultHelp = `cmder - build powerful command-line applications in Go
 
 'cmder' is a simple and flexible library for building command-line interfaces in Go. If you're coming from Cobra and
 have used it for any length of time, you have surely had your fair share of difficulties with the library. 'cmder' will
@@ -84,36 +84,7 @@ Flags:
 Use "test [command] --help" for more information about a command.
 `
 
-const ExpectedStdFlagUsageTemplate = `usage: test [subcommands] [flags] [args]
-  -a address
-    	address and port of the device (e.g. 192.168.1.1:4567)
-  -addr address
-    	address and port of the device (e.g. 192.168.1.1:4567)
-  -arg key=value
-    	render template with arguments (key=value) (default k=v)
-  -hosts value
-    	specify remote hosts (e.g. tcp://127.0.0.1) (default hello,world)
-  -poll-interval value
-    	attempt to poll the device status more frequently than advertised (default 0s)
-  -r value
-    	specify remote hosts (e.g. tcp://127.0.0.1) (default hello,world)
-  -reconnect-interval duration
-    	interval between connection attempts (e.g. 1m) (default 1m0s)
-  -s serial
-    	serial number of the device (e.g. 10293894a)
-  -serial-number serial
-    	serial number of the device (e.g. 10293894a)
-  -t key=value
-    	render template with arguments (key=value) (default k=v)
-  -web.disable-exporter-metrics
-    	exclude metrics about the exporter itself (go_*)
-  -web.listen-address string
-    	address on which to expose metrics (default ":9090")
-  -web.telemetry-path string
-    	path under which to expose metrics (default "/metrics")
-`
-
-func TestUsage(t *testing.T) {
+func TestHelp(t *testing.T) {
 	child1 := &BaseCommand{
 		CommandName: "child-1",
 		CommandDocumentation: CommandDocumentation{
@@ -168,17 +139,17 @@ func TestUsage(t *testing.T) {
 	cmd.fs.String("web.telemetry-path", "/metrics", "path under which to expose metrics")
 	cmd.fs.Bool("web.disable-exporter-metrics", false, "exclude metrics about the exporter itself (go_*)")
 
-	t.Run("CobraUsageTemplate", func(t *testing.T) {
+	t.Run("DefaultHelpTemplate", func(t *testing.T) {
 		t.Run("should render correctly", func(t *testing.T) {
 			var buf bytes.Buffer
 
-			err := usage(cmd, &ExecuteOptions{
-				usageTemplate: CobraUsageTemplate,
-				usageWriter:   &buf,
+			err := help(cmd, &ExecuteOptions{
+				helpTemplate: DefaultHelpTemplate,
+				outputWriter: &buf,
 			})
 			assert(t, nilerr(err))
 
-			if diff := cmp.Diff(ExpectedCobraUsageTemplate, buf.String()); diff != "" {
+			if diff := cmp.Diff(ExpectedDefaultHelp, buf.String()); diff != "" {
 				t.Fatalf("usage text mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -197,29 +168,13 @@ func TestUsage(t *testing.T) {
 
 			var buf bytes.Buffer
 
-			err := usage(cmd, &ExecuteOptions{
-				usageTemplate: CobraUsageTemplate,
-				usageWriter:   &buf,
+			err := help(cmd, &ExecuteOptions{
+				helpTemplate: DefaultHelpTemplate,
+				outputWriter: &buf,
 			})
 			assert(t, nilerr(err))
 
-			if diff := cmp.Diff(ExpectedCobraUsageTemplate, buf.String()); diff != "" {
-				t.Fatalf("usage text mismatch (-want +got):\n%s", diff)
-			}
-		})
-	})
-
-	t.Run("StdFlagUsageTemplate", func(t *testing.T) {
-		t.Run("should render correctly", func(t *testing.T) {
-			var buf bytes.Buffer
-
-			err := usage(cmd, &ExecuteOptions{
-				usageTemplate: StdFlagUsageTemplate,
-				usageWriter:   &buf,
-			})
-			assert(t, nilerr(err))
-
-			if diff := cmp.Diff(ExpectedStdFlagUsageTemplate, buf.String()); diff != "" {
+			if diff := cmp.Diff(ExpectedDefaultHelp, buf.String()); diff != "" {
 				t.Fatalf("usage text mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Prior to this revision, -h and --help flags rendered complete help text. This revision adjusts this slightly, now differentiating between usage text ('-h') and longer help text ('--help'). The usage text offers a short command summary, and the help text offers longer doc-style text.

With this, a few adjustments were made to the usage machinery and the relevant execute options.

Usage/help text is now rendered to stdout by default. This makes it easier to pass the output through a paging program like 'less' or 'more'.

The custom flag value types in the getopt package now feature short constructor functions (e.g. getopt.Time, getopt.Map). Examples have been updated.

The 'http' example has been updated with improved flag descriptions.