### PR TITLE
feat(getopt): introduce negated bool var type

### DIFF
--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/brandon1024/cmder"
+	"github.com/brandon1024/cmder/getopt"
 )
 
 func main() {
@@ -90,8 +91,8 @@ type ServerCommand struct {
 	// The value of this field is a username and password with format `user:pass`.
 	basicAuth string
 
-	// If configured, basic auth is disabled.
-	noAuth bool
+	// If configured, auth is enabled.
+	auth bool
 }
 
 func (c *ServerCommand) InitializeFlags(fs *flag.FlagSet) {
@@ -107,8 +108,9 @@ func (c *ServerCommand) InitializeFlags(fs *flag.FlagSet) {
 		"Set the maximum request body size, in bytes. Negative or zero disables the limit.")
 	fs.StringVar(&c.basicAuth, "http.auth-basic", "",
 		"Configure basic auth credentials with format `user:pass`.")
-	fs.BoolVar(&c.noAuth, "http.no-auth", false,
-		"Disable basic auth, making the server available to all.")
+
+	fs.BoolVar(&c.auth, "http.auth", true, "Enable basic auth. Basic auth credentials must be configured with 'http.auth-basic' option.")
+	fs.Var(getopt.NegatedBool(&c.auth), "http.no-auth", "Disable basic auth, making the server available to all.")
 }
 
 func (c *ServerCommand) Initialize(ctx context.Context, args []string) error {
@@ -117,7 +119,7 @@ func (c *ServerCommand) Initialize(ctx context.Context, args []string) error {
 		return cmder.ErrShowUsage
 	}
 
-	if !c.noAuth && c.basicAuth == "" {
+	if c.auth && c.basicAuth == "" {
 		var (
 			user = "admin"
 			pass = uuid.New().String()

--- a/examples/http/routes.go
+++ b/examples/http/routes.go
@@ -26,7 +26,7 @@ func (c *ServerCommand) route(h http.HandlerFunc) http.HandlerFunc {
 
 		// auth
 		u, p, ok := r.BasicAuth()
-		if !c.noAuth && (!ok || c.basicAuth != u+":"+p) {
+		if c.auth && (!ok || c.basicAuth != u+":"+p) {
 			slog.Warn("client request denied: missing or invalid credentials", "method", r.Method, "addr", r.RemoteAddr,
 				"uri", r.URL.Path)
 
@@ -35,7 +35,7 @@ func (c *ServerCommand) route(h http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		if !c.noAuth {
+		if c.auth {
 			slog.Info("client authenticated", "method", r.Method, "addr", r.RemoteAddr, "uri", r.URL.Path, "user", u)
 		}
 

--- a/getopt/bool.go
+++ b/getopt/bool.go
@@ -1,6 +1,47 @@
 package getopt
 
-import "flag"
+import (
+	"flag"
+	"strconv"
+)
+
+// NegatedBoolVar is a boolean [flag.Value] for negating other flag values. A typical use case for NegatedBoolVar is to
+// register flags which disable/unset other flags.
+//
+//	--show
+//	--no-show
+type NegatedBoolVar bool
+
+// NegatedBool builds a [NegatedBoolVar] backed by b.
+func NegatedBool(v *bool) *NegatedBoolVar {
+	return (*NegatedBoolVar)(v)
+}
+
+// String returns the string representation of the (negated) boolean value.
+func (b *NegatedBoolVar) String() string {
+	return strconv.FormatBool(!bool(*b))
+}
+
+// Set updates the value of the flag. The given value must be a string parseable by [strconv.ParseBool]. The flag value
+// is updated with the (negated) value s.
+func (b *NegatedBoolVar) Set(s string) error {
+	val, err := strconv.ParseBool(s)
+	if err == nil {
+		*b = NegatedBoolVar(!val)
+	}
+
+	return err
+}
+
+// IsBoolFlag marks the flag is not accepting args.
+func (b *NegatedBoolVar) IsBoolFlag() bool {
+	return true
+}
+
+// Get fulfills the [flag.Getter] interface, allowing typed access to the flag value. In this case, returns a bool.
+func (b *NegatedBoolVar) Get() any {
+	return !bool(*b)
+}
 
 // boolFlag is a [flag.Value] that also implements a method IsBoolFlag, used to determine if the flag accepts an
 // argument or not.

--- a/getopt/example_counter_test.go
+++ b/getopt/example_counter_test.go
@@ -3,22 +3,30 @@ package getopt_test
 import (
 	"flag"
 	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/brandon1024/cmder/getopt"
 )
 
-// This example demonstrates the usage of [getopt.Counter].
+// This example demonstrates the usage of [getopt.Counter], configuring the log level of the default logger.
 func ExampleCounter() {
-	var verbose uint
+	var verbosity slog.Level
 
 	fs := getopt.NewPosixFlagSet("counter", flag.ContinueOnError)
-	fs.Var(getopt.Counter(&verbose), "v", "increase verbosity")
+	fs.Var(getopt.Counter(&verbosity), "v", "increase verbosity")
 
 	if err := fs.Parse([]string{"-vvv"}); err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("verbosity: %d\n", verbose)
+	lvl := slog.LevelError - verbosity*4
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: lvl,
+	})))
+
+	fmt.Printf("verbosity: %s\n", lvl.String())
 	// Output:
-	// verbosity: 3
+	// verbosity: DEBUG
 }

--- a/getopt/example_negatedboolvar_test.go
+++ b/getopt/example_negatedboolvar_test.go
@@ -1,0 +1,41 @@
+package getopt_test
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/brandon1024/cmder/getopt"
+)
+
+// This example demonstrates the usage of [getopt.NegatedBoolVar].
+func ExampleNegatedBoolVar() {
+	var (
+		sign   bool
+		verify bool
+	)
+
+	fs := flag.NewFlagSet("custom", flag.ContinueOnError)
+
+	// option 1: using NegatedBoolVar directly
+	fs.BoolVar(&sign, "gpg-sign", false, "gpg sign the input")
+	fs.Var((*getopt.NegatedBoolVar)(&sign), "no-gpg-sign", "skip gpg signing")
+
+	// option 2: with NegatedBool
+	fs.BoolVar(&verify, "verify", false, "verify the result")
+	fs.Var(getopt.NegatedBool(&verify), "no-verify", "skip result verification")
+
+	args := []string{
+		"-gpg-sign", "-no-gpg-sign",
+		"-no-verify=false",
+	}
+
+	if err := fs.Parse(args); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("sign: %v\n", sign)
+	fmt.Printf("verify: %v\n", verify)
+	// Output:
+	// sign: false
+	// verify: true
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/brandon1024/cmder
 
 go 1.24.0
 
-toolchain go1.26.0
+toolchain go1.26.2
 
 tool (
 	golang.org/x/tools/cmd/goimports

--- a/usage_test.go
+++ b/usage_test.go
@@ -121,15 +121,15 @@ func TestHelp(t *testing.T) {
 	}
 
 	cmd.fs.String("serial-number", "", "`serial` number of the device (e.g. 10293894a)")
-	cmd.fs.Var(alias(cmd.fs.Lookup("serial-number"), "s"))
+	getopt.Alias(cmd.fs, "serial-number", "s")
 	cmd.fs.String("addr", "", "`address` and port of the device (e.g. 192.168.1.1:4567)")
-	cmd.fs.Var(alias(cmd.fs.Lookup("addr"), "a"))
+	getopt.Alias(cmd.fs, "addr", "a")
 
 	cmd.fs.Var(getopt.MapVar{"k": "v"}, "arg", "render template with arguments (`key=value`)")
-	cmd.fs.Var(alias(cmd.fs.Lookup("arg"), "t"))
+	getopt.Alias(cmd.fs, "arg", "t")
 
 	cmd.fs.Var(&getopt.StringsVar{"hello", "world"}, "hosts", "specify remote hosts (e.g. tcp://127.0.0.1)")
-	cmd.fs.Var(alias(cmd.fs.Lookup("hosts"), "r"))
+	getopt.Alias(cmd.fs, "hosts", "r")
 
 	cmd.fs.Duration("poll-interval", time.Duration(0), "attempt to poll the device status more frequently than advertised")
 	getopt.Hide(cmd.fs, "poll-interval")


### PR DESCRIPTION
This revision introduces a new type NegatedBoolVar in package getopt for representing boolean flags which are the inverse of another flag. For instance, configuring a '--no-gpg-sign' flag.

Additionally, the CounterVar example has been improved with a more motivating example.

Update Go toolchain to 1.26.2.