### PR TITLE
feat(getopt): add option to permit partial name matches for long flags

### DIFF
--- a/example_exec_options_test.go
+++ b/example_exec_options_test.go
@@ -27,6 +27,22 @@ func ExampleWithInterspersedArgs() {
 	// 0559406fc9a7b5704464c303ebbba64c
 }
 
+func ExampleWithRelaxedFlagParsing() {
+	// note that shorthand '--al' is permitted for flag '--algo'
+	args := []string{"--al", "md5", "relaxed-parsing"}
+
+	ops := []cmder.ExecuteOption{
+		cmder.WithArgs(args),
+		cmder.WithRelaxedFlagParsing(),
+	}
+
+	if err := cmder.Execute(context.Background(), hasher, ops...); err != nil {
+		fmt.Printf("unexpected error occurred: %v", err)
+	}
+	// Output:
+	// 21db31e27ddc3aef918b031bd978fa78
+}
+
 const HashDesc = `
 'hash' demonstrates how cmder can be configured to parse args with interspersed args and flags. The command generates
 and prints a hash of the concatenated command args.

--- a/execute.go
+++ b/execute.go
@@ -267,7 +267,7 @@ func buildCallStack(cmd Command, ops *ExecuteOptions) ([]command, error) {
 
 // parseArgs processes args for the given command, returning the unparsed (remaining) arguments.
 func parseArgs(cmd command, args []string, ops *ExecuteOptions) ([]string, error) {
-	var fp flagParser = &getopt.PosixFlagSet{FlagSet: cmd.fs}
+	var fp flagParser = &getopt.PosixFlagSet{FlagSet: cmd.fs, RelaxedParsing: ops.relaxedFlags}
 
 	if ops.nativeFlags {
 		fp = cmd.fs

--- a/getopt/flagset.go
+++ b/getopt/flagset.go
@@ -86,6 +86,14 @@ import (
 type PosixFlagSet struct {
 	*flag.FlagSet
 
+	// Similar to [flag.FlagSet.Usage], Usage is invoked when parsing fails. By default, uses
+	// [PosixFlagSet.PrintDefaults] which renders flag usage with posix semantics.
+	Usage func()
+
+	// If true, relaxes flag parsing allowing Parse to accept partial flag matches (e.g. '--auto' for '--auto-gc'). An
+	// error will still be emitted if the input is ambiguous (e.g. '--auto' for '--auto-gc' or '--auto-maintenance').
+	RelaxedParsing bool
+
 	parsed bool
 	args   []string
 }
@@ -213,15 +221,19 @@ func (f *PosixFlagSet) parse(arguments []string) error {
 	for len(arguments) > 0 {
 		arg := arguments[0]
 
+		// a single hyphen is not a flag -- update arguments and return
 		if arg == "-" {
 			f.args = arguments[0:]
 			return nil
 		}
+
+		// double hyphens is sentinel and denotes end of arguments -- remove from arguments and return
 		if arg == "--" {
 			f.args = arguments[1:]
 			return nil
 		}
 
+		// parse long option
 		long, ok := strings.CutPrefix(arg, "--")
 		if ok {
 			arguments, err = f.parseLong(long, arguments[1:])
@@ -232,6 +244,7 @@ func (f *PosixFlagSet) parse(arguments []string) error {
 			continue
 		}
 
+		// parse short option
 		short, ok := strings.CutPrefix(arg, "-")
 		if ok {
 			arguments, err = f.parseShort(short, arguments[1:])
@@ -253,10 +266,13 @@ func (f *PosixFlagSet) parse(arguments []string) error {
 func (f *PosixFlagSet) parseLong(arg string, arguments []string) ([]string, error) {
 	arg, value, inlineVal := strings.Cut(arg, "=")
 
-	flg := f.Lookup(arg)
+	flg := f.lookupLong(arg, f.RelaxedParsing)
+
+	// similar to the stdlib, if we encounter a '--help' flag but none defined, return ErrHelp
 	if flg == nil && arg == "help" {
 		return nil, flag.ErrHelp
 	}
+
 	if flg == nil {
 		return nil, fmt.Errorf("flag '--%s' does not exist", arg)
 	}
@@ -266,6 +282,7 @@ func (f *PosixFlagSet) parseLong(arg string, arguments []string) ([]string, erro
 			value = "true"
 		}
 	} else {
+		// if the value was not provided inline '--arg=value', grab the next argument
 		if !inlineVal {
 			if len(arguments) == 0 {
 				return nil, fmt.Errorf("missing argument to flag '--%s'", arg)
@@ -275,7 +292,7 @@ func (f *PosixFlagSet) parseLong(arg string, arguments []string) ([]string, erro
 		}
 	}
 
-	if err := f.Set(arg, value); err != nil {
+	if err := f.Set(flg.Name, value); err != nil {
 		return nil, err
 	}
 
@@ -329,4 +346,37 @@ func (f *PosixFlagSet) parseShort(short string, arguments []string) ([]string, e
 	}
 
 	return arguments, nil
+}
+
+// lookupLong looks for a (long) flag with the given name in f. Returns nil if no flag found.
+//
+// When relaxed is true, partial flag name matches are permitted. If more than one flag name has the prefix name,
+// returns nil.
+func (f *PosixFlagSet) lookupLong(name string, relaxed bool) *flag.Flag {
+	// never match a short name, since the user is expected to use short-style flags instead ('-a' and not '--a')
+	if len(name) <= 1 {
+		return nil
+	}
+
+	var flags []*flag.Flag
+
+	f.VisitAll(func(flg *flag.Flag) {
+		// don't match short flags
+		if len(flg.Name) <= 1 {
+			return
+		}
+
+		if !relaxed && flg.Name == name {
+			flags = append(flags, flg)
+		}
+		if relaxed && strings.HasPrefix(flg.Name, name) {
+			flags = append(flags, flg)
+		}
+	})
+
+	if len(flags) != 1 {
+		return nil
+	}
+
+	return flags[0]
 }

--- a/getopt/flagset_test.go
+++ b/getopt/flagset_test.go
@@ -631,6 +631,140 @@ func TestPosixFlagSet(t *testing.T) {
 				t.Fatalf("output var not updated with expected value: %s", output)
 			}
 		})
+
+		t.Run("should exactly match flag names when relaxed parsing disabled", func(t *testing.T) {
+			var autoGc, autoMaintenance bool
+
+			fs := NewPosixFlagSet("test", flag.ContinueOnError)
+			fs.BoolVar(&autoGc, "auto-gc", false, "enable automatic garbage collection")
+			fs.BoolVar(&autoMaintenance, "auto-maintenance", false, "enable automatic maintenance")
+
+			err := fs.Parse([]string{"--auto-m"})
+			if err == nil {
+				t.Fatalf("expected error but was nil")
+			}
+			if !strings.Contains(err.Error(), "flag '--auto-m' does not exist") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		t.Run("should permit partial flag names when relaxed parsing enabled", func(t *testing.T) {
+			var autoGc, autoMaintenance bool
+			var algo string
+
+			fs := NewPosixFlagSet("test", flag.ContinueOnError)
+			fs.RelaxedParsing = true
+
+			fs.BoolVar(&autoGc, "auto-gc", false, "enable automatic garbage collection")
+			fs.BoolVar(&autoMaintenance, "auto-maintenance", false, "enable automatic maintenance")
+			fs.StringVar(&algo, "algorithm", "sha256", "specify an algorithm")
+
+			err := fs.Parse([]string{"--auto-m", "--al=md5"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if autoGc {
+				t.Fatalf("flag set unexpectedly: auto-gc")
+			}
+			if !autoMaintenance {
+				t.Fatalf("flag set unexpectedly: auto-maintenance")
+			}
+			if algo != "md5" {
+				t.Fatalf("unexpected flag value for algorithm: %s", algo)
+			}
+		})
+
+		t.Run("should not parse long format flags with short names", func(t *testing.T) {
+			var output string
+
+			fs := NewPosixFlagSet("test", flag.ContinueOnError)
+			fs.StringVar(&output, "output", "-", "output `file`")
+			fs.StringVar(&output, "a", "-", "output `file`")
+
+			err := fs.Parse([]string{"--a", "test.json"})
+			if err == nil {
+				t.Fatalf("expected error but was nil")
+			}
+			if !strings.Contains(err.Error(), "flag '--a' does not exist") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	})
+
+	t.Run("Visit", func(t *testing.T) {
+		t.Run("should correctly visit only set flags", func(t *testing.T) {
+			var (
+				count  uint
+				output string
+				all    bool
+			)
+
+			fs := NewPosixFlagSet("test", flag.ContinueOnError)
+			fs.UintVar(&count, "count", 12, "`number` of results")
+			fs.UintVar(&count, "c", 12, "`number` of results")
+			fs.StringVar(&output, "output", "-", "output `file`")
+			fs.StringVar(&output, "o", "-", "output `file`")
+			fs.BoolVar(&all, "all", false, "show `all`")
+			fs.BoolVar(&all, "a", false, "show `all`")
+
+			err := fs.Parse([]string{"-ac10", "--output=test.json"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var visited []string
+
+			fs.Visit(func(flg *flag.Flag) {
+				visited = append(visited, flg.Name)
+			})
+
+			if len(visited) != 3 {
+				t.Fatalf("unexpected number of flags visited: %d", len(visited))
+			}
+			if !slices.Contains(visited, "a") {
+				t.Fatalf("missing flag 'a': %v", visited)
+			}
+			if !slices.Contains(visited, "c") {
+				t.Fatalf("missing flag 'c': %v", visited)
+			}
+			if !slices.Contains(visited, "output") {
+				t.Fatalf("missing flag 'output': %v", visited)
+			}
+		})
+	})
+
+	t.Run("VisitAll", func(t *testing.T) {
+		t.Run("should correctly visit all flags", func(t *testing.T) {
+			var (
+				count  uint
+				output string
+				all    bool
+			)
+
+			fs := NewPosixFlagSet("test", flag.ContinueOnError)
+			fs.UintVar(&count, "count", 12, "`number` of results")
+			fs.UintVar(&count, "c", 12, "`number` of results")
+			fs.StringVar(&output, "output", "-", "output `file`")
+			fs.StringVar(&output, "o", "-", "output `file`")
+			fs.BoolVar(&all, "all", false, "show `all`")
+			fs.BoolVar(&all, "a", false, "show `all`")
+
+			err := fs.Parse([]string{"-ac10", "--output=test.json"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var visited []string
+
+			fs.VisitAll(func(flg *flag.Flag) {
+				visited = append(visited, flg.Name)
+			})
+
+			if len(visited) != 6 {
+				t.Fatalf("unexpected number of flags visited: %d", len(visited))
+			}
+		})
 	})
 
 	t.Run("PrintDefaults", func(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ import "io"
 type ExecuteOptions struct {
 	args          []string
 	nativeFlags   bool
+	relaxedFlags  bool
 	bindEnv       bool
 	bindEnvPrefix string
 	interspersed  bool
@@ -31,6 +32,16 @@ func WithArgs(args []string) ExecuteOption {
 func WithNativeFlags() ExecuteOption {
 	return func(ops *ExecuteOptions) {
 		ops.nativeFlags = true
+	}
+}
+
+// WithRelaxedFlagParsing instructs [Execute] to relax flag parsing. Partial name matches for long flags are permitted,
+// granted the provided flag name is not ambiguous.
+//
+// This option is ignored if [WithNativeFlags] is enabled.
+func WithRelaxedFlagParsing() ExecuteOption {
+	return func(ops *ExecuteOptions) {
+		ops.relaxedFlags = true
 	}
 }
 


### PR DESCRIPTION
This revision introduces a new field PosixFlagSet.RelaxedParsing which relaxes the parser to permit partial name matches for long flags. For example, when enabled, '--al' would match the flag '--algorithm', assuming no other flag names have the prefix 'al'.

An associated ExecuteOption was added to enable this functionality. By default, relaxed parsing is disabled.

Improved test coverage of PosixFlagSet.

This revision also fixes a few bugs in package getopt. When a new flag set is created with NewPosixFlagSet, the wrong usage renderer was being called when flag parsing fails. Additionally, long-format flags were incorrectly matching short flags (e.g. '--a' accepted for flag 'a', but should not match). These bugs have been corrected and tests have been added.