### PR TITLE
enhance(usage): adjust flag usage renderer to skip zero value defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,20 @@ commands, but that's about it. `cmder` embraces simplicity because sometimes,
 less is better. The wide range of examples throughout the project should help
 you get started.
 
-To define a new command, simply define a type that implements the `Command`
-interface. If you want your command to have additional behavior like flags or
-subcommands, simply implement the appropriate interfaces.
+To define a new command, simply define a type that implements the
+[`Command`](https://pkg.go.dev/github.com/brandon1024/cmder#Command) interface.
+If you want your command to have additional behavior like flags or subcommands,
+simply implement the appropriate interfaces.
 
 Here are some highlights:
 
-- Bring your own types. `cmder` doesn't force you to use special `command`
-  structs. As long as you implement our narrow interfaces, you're good to go!
-- `cmder` is unobtrusive. Define your command and execute it. Simplicity above
-  all else!
+- `cmder` doesn't force you to use special `command` structs. As long as you
+  implement our narrow interfaces, you're good to go.
+- `cmder` is unobtrusive. Define your command and execute it.
 - `cmder` is totally stateless making it super easy to unit test your commands.
   This isn't the case in other libraries.
+- `cmder` natively supports getopt-style flag parsing, but you can use the
+  standard flag library instead if you prefer.
 - We take great pride in our documentation. If you find anything unclear, please
   let us know so we can fix it.
 

--- a/doc.go
+++ b/doc.go
@@ -7,10 +7,11 @@ throughout the project should help you get started.
 To define a new command, simply define a type that implements the [Command] interface. If you want your command to have
 additional behavior like flags or subcommands, simply implement the appropriate interfaces.
 
-  - Bring your own types. cmder doesn't force you to use special command structs. As long as you implement our narrow
-    interfaces, you're good to go!
-  - cmder is unobtrusive. Define your command and execute it. Simplicity above all else!
+  - cmder doesn't force you to use special command structs. As long as you implement our narrow interfaces, you're good
+    to go.
+  - cmder is unobtrusive. Define your command and execute it.
   - cmder is totally stateless making it super easy to unit test your commands. This isn't the case in other libraries.
+  - cmder natively supports getopt-style flag parsing, but you can use the standard flag library instead if you prefer.
   - We take great pride in our documentation. If you find anything unclear, please let us know so we can fix it.
 
 To get started, see [Command] and [Execute].

--- a/getopt/countervar_test.go
+++ b/getopt/countervar_test.go
@@ -35,4 +35,18 @@ func TestCounterVar(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("should not panic if calling String on zero or nil value", func(t *testing.T) {
+		var z CounterVar[uint16]
+
+		if result := z.String(); result != "0" {
+			t.Fatalf("unexpected result: %s", result)
+		}
+
+		var zp *CounterVar[uint16]
+
+		if result := zp.String(); result != "0" {
+			t.Fatalf("unexpected result: %s", result)
+		}
+	})
 }

--- a/getopt/mapvar_test.go
+++ b/getopt/mapvar_test.go
@@ -126,4 +126,12 @@ func TestMapVar(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("should not panic if calling String on nil value", func(t *testing.T) {
+		var z MapVar
+
+		if result := z.String(); result != "" {
+			t.Fatalf("unexpected result: %s", result)
+		}
+	})
 }

--- a/getopt/stringsvar_test.go
+++ b/getopt/stringsvar_test.go
@@ -1,0 +1,13 @@
+package getopt
+
+import "testing"
+
+func TestStringsVar(t *testing.T) {
+	t.Run("should not panic if calling String on nil value", func(t *testing.T) {
+		var z StringsVar
+
+		if result := z.String(); result != "" {
+			t.Fatalf("unexpected result: %s", result)
+		}
+	})
+}

--- a/getopt/timevar.go
+++ b/getopt/timevar.go
@@ -14,8 +14,8 @@ func Time(tm *time.Time) *TimeVar {
 }
 
 // String returns the [time.RFC3339] representation of the timestamp flag.
-func (t *TimeVar) String() string {
-	return time.Time(*t).Format(time.RFC3339)
+func (t TimeVar) String() string {
+	return time.Time(t).Format(time.RFC3339)
 }
 
 // Set fulfills the [flag.Value] interface. The given value must be a correctly formatted [time.RFC3339] timestamp.

--- a/getopt/timevar_test.go
+++ b/getopt/timevar_test.go
@@ -1,0 +1,13 @@
+package getopt
+
+import "testing"
+
+func TestTimeVar(t *testing.T) {
+	t.Run("should not panic if calling String on nil value", func(t *testing.T) {
+		var z TimeVar
+
+		if result := z.String(); result != "0001-01-01T00:00:00Z" {
+			t.Fatalf("unexpected result: %s", result)
+		}
+	})
+}

--- a/usage.go
+++ b/usage.go
@@ -4,6 +4,8 @@ import (
 	"cmp"
 	"errors"
 	"flag"
+	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"text/template"
@@ -15,11 +17,18 @@ const DefaultHelpTemplate = `{{ trim .Command.HelpText }}{{ println }}{{ println
 
 // DefaultUsageTemplate is a text template for rendering command usage information.
 const DefaultUsageTemplate = `Usage:
-  {{ trim .Command.UsageLine }}
-
-Examples:
-{{ range (lines (trim .Command.ExampleText)) }}  {{ . }}{{ end }}
 {{- println -}}
+{{- printf "  %s" (trim .Command.UsageLine) -}}
+{{- println -}}
+
+{{- with .Command.ExampleText -}}
+	{{- println -}}
+	{{- println "Examples:" -}}
+	{{- range (lines (trim .)) -}}
+		{{- printf "  %s" . -}}
+	{{- end -}}
+	{{- println -}}
+{{- end -}}
 
 {{- with (commands .) -}}
 	{{- println -}}
@@ -63,8 +72,8 @@ Examples:
 			{{- end -}}
 		{{- end -}}
 
-		{{ with (index . 0).DefValue }}
-			{{- printf " (default %s)" . -}}
+		{{ if (not (zero (index . 0))) }}
+			{{- printf " (default %s)" (index . 0).DefValue -}}
 		{{- end -}}
 
 		{{- println -}}
@@ -111,6 +120,7 @@ func help(cmd command, ops *ExecuteOptions) error {
 //   - commands(c):            Collect all subcommands of c into a map, keyed by name.
 //   - flags(c):               Collect all flags of c, organized by flag group name.
 //   - unquote(f):             Call UnquoteUsage on flag f.
+//   - zero(f):                Check if the default value for f is the zero value or not.
 //   - lower(str):             Return string argument in lowercase.
 //   - upper(str):             Return string argument in uppercase.
 //   - split(str):             Split a string.
@@ -124,6 +134,7 @@ func funcs() template.FuncMap {
 		"commands": subcommands,
 		"flags":    flags,
 		"unquote":  unquote,
+		"zero":     zero,
 		"lower":    strings.ToLower,
 		"upper":    strings.ToUpper,
 		"split":    strings.Split,
@@ -234,4 +245,31 @@ func unquote(flg *flag.Flag) []string {
 	}
 
 	return []string{name, usage}
+}
+
+// zero checks if the default value of flg is the zero value for its type. This is used when rendering usage text
+// to render default flag values only when the default value is interesting.
+//
+// This function expects that flg adhere's to the same requirements of the stdlib [flag] package, notably:
+//
+//	The flag package may call the String method with a zero-valued receiver, such as a nil pointer.
+//
+// Flags that don't respect this requirement will result in an error.
+func zero(flg *flag.Flag) (ok bool, err error) {
+	var z reflect.Value
+
+	if typ := reflect.TypeOf(flg.Value); typ.Kind() == reflect.Pointer {
+		z = reflect.New(typ.Elem())
+	} else {
+		z = reflect.Zero(typ)
+	}
+
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("cmder: flag '%s' is backed by a type that does not accept calling String() on the zero value (bug): %v",
+				flg.Name, e)
+		}
+	}()
+
+	return flg.DefValue == z.Interface().(flag.Value).String(), nil
 }

--- a/usage_test.go
+++ b/usage_test.go
@@ -3,6 +3,7 @@ package cmder
 import (
 	"bytes"
 	"flag"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -72,7 +73,7 @@ Flags:
   -s <serial>, --serial-number=<serial>
       serial number of the device (e.g. 10293894a)
 
-  --web.disable-exporter-metrics (default false)
+  --web.disable-exporter-metrics
       exclude metrics about the exporter itself (go_*)
 
   --web.listen-address=<string> (default :9090)
@@ -149,6 +150,8 @@ func TestHelp(t *testing.T) {
 			})
 			assert(t, nilerr(err))
 
+			t.Logf("result:\n%s", buf.String())
+
 			if diff := cmp.Diff(ExpectedDefaultHelp, buf.String()); diff != "" {
 				t.Fatalf("usage text mismatch (-want +got):\n%s", diff)
 			}
@@ -174,10 +177,220 @@ func TestHelp(t *testing.T) {
 			})
 			assert(t, nilerr(err))
 
+			t.Logf("result:\n%s", buf.String())
+
 			if diff := cmp.Diff(ExpectedDefaultHelp, buf.String()); diff != "" {
 				t.Fatalf("usage text mismatch (-want +got):\n%s", diff)
 			}
 		})
+	})
+}
+
+const ExpectedDefaultUsage = `Usage:
+  example [flags] [args]
+
+Examples:
+  example --bool-flag --int-flag=1 arg
+
+Flags:
+  --bool-func-non-zero
+      bool func with non-zero default value
+
+  --func-zero=<value>, --bool-func-zero
+      func with zero default value
+
+  --bool-non-zero (default true)
+      bool with non-zero default value
+
+  --bool-zero
+      bool with zero default value
+
+  --counter-non-zero (default 12)
+      counter with non-zero default value
+
+  --counter-zero
+      counter with zero default value
+
+  --duration-non-zero=<duration> (default 1s)
+      duration with non-zero default value
+
+  --duration-zero=<duration>
+      duration with zero default value
+
+  --float64-non-zero=<float> (default 1)
+      float64 with non-zero default value
+
+  --float64-zero=<float>
+      float64 with zero default value
+
+  --func-non-zero=<value>
+      func with non-zero default value
+
+  --int-non-zero=<int> (default 12)
+      int with non-zero default value
+
+  --int-zero=<int>
+      int with zero default value
+
+  --int64-non-zero=<int> (default 13)
+      int64 with non-zero default value
+
+  --int64-zero=<int>
+      int64 with zero default value
+
+  --map-non-zero=<value> (default k=v)
+      map flag with non-zero default value
+
+  --map-zero=<value>
+      map flag with zero default value
+
+  --neg-bool-non-zero (default false)
+      negated bool with non-zero default value
+
+  --neg-bool-zero
+      negated bool with zero default value
+
+  --string-non-zero=<string> (default test)
+      string with non-zero default value
+
+  --string-zero=<string>
+      string with zero default value
+
+  --strings-non-zero=<value> (default item)
+      string slice flag with non-zero default value
+
+  --strings-zero=<value>
+      string slice flag with zero default value
+
+  --text-non-zero=<value> (default ERROR)
+      textvar with non-zero default value
+
+  --text-zero=<value> (default INFO)
+      textvar with zero default value
+
+  --time-non-zero=<value> (default 1970-01-04T00:00:00Z)
+      time flag with non-zero default value
+
+  --time-zero=<value>
+      time flag with zero default value
+
+  --uint-non-zero=<uint> (default 14)
+      uint with non-zero default value
+
+  --uint-zero=<uint>
+      uint with zero default value
+
+  --uint64-non-zero=<uint> (default 15)
+      uint64 with non-zero default value
+
+  --uint64-zero=<uint>
+      uint64 with zero default value
+`
+
+func TestUsage(t *testing.T) {
+	t.Run("should correctly render default flag values", func(t *testing.T) {
+		cmd := command{
+			Command: &BaseCommand{
+				CommandName: "example",
+				CommandDocumentation: CommandDocumentation{
+					Usage:     "example [flags] [args]",
+					ShortHelp: "Example Command",
+					Help:      "This is a simple example.",
+					Examples:  "example --bool-flag --int-flag=1 arg",
+				},
+			},
+			fs: flag.NewFlagSet("cmd", flag.ContinueOnError),
+		}
+
+		// native var types
+		var (
+			boolZero        bool
+			boolNonZero     = true
+			boolFuncZero    func(string) error
+			boolFuncNonZero = func(string) error { return nil }
+			durationZero    time.Duration
+			durationNonZero = time.Second
+			floatZero       float64
+			floatNonZero    = 1.0
+			funcZero        func(string) error
+			funcNonZero     = func(string) error { return nil }
+			intZero         int
+			intNonZero      = 12
+			int64Zero       int64
+			int64NonZero    int64 = 13
+			uintZero        uint
+			uintNonZero     uint = 14
+			uint64Zero      uint64
+			uint64NonZero   uint64 = 15
+			stringZero      string
+			stringNonZero   = "test"
+			textZero        slog.Level
+			textNonZero     = slog.LevelError
+		)
+		cmd.fs.BoolVar(&boolZero, "bool-zero", boolZero, "bool with zero default value")
+		cmd.fs.BoolVar(&boolNonZero, "bool-non-zero", boolNonZero, "bool with non-zero default value")
+		cmd.fs.BoolFunc("bool-func-zero", "bool func with zero default value", boolFuncZero)
+		cmd.fs.BoolFunc("bool-func-non-zero", "bool func with non-zero default value", boolFuncNonZero)
+		cmd.fs.DurationVar(&durationZero, "duration-zero", durationZero, "duration with zero default value")
+		cmd.fs.DurationVar(&durationNonZero, "duration-non-zero", durationNonZero, "duration with non-zero default value")
+		cmd.fs.Float64Var(&floatZero, "float64-zero", floatZero, "float64 with zero default value")
+		cmd.fs.Float64Var(&floatNonZero, "float64-non-zero", floatNonZero, "float64 with non-zero default value")
+		cmd.fs.Func("func-zero", "func with zero default value", funcZero)
+		cmd.fs.Func("func-non-zero", "func with non-zero default value", funcNonZero)
+		cmd.fs.IntVar(&intZero, "int-zero", intZero, "int with zero default value")
+		cmd.fs.IntVar(&intNonZero, "int-non-zero", intNonZero, "int with non-zero default value")
+		cmd.fs.Int64Var(&int64Zero, "int64-zero", int64Zero, "int64 with zero default value")
+		cmd.fs.Int64Var(&int64NonZero, "int64-non-zero", int64NonZero, "int64 with non-zero default value")
+		cmd.fs.UintVar(&uintZero, "uint-zero", uintZero, "uint with zero default value")
+		cmd.fs.UintVar(&uintNonZero, "uint-non-zero", uintNonZero, "uint with non-zero default value")
+		cmd.fs.Uint64Var(&uint64Zero, "uint64-zero", uint64Zero, "uint64 with zero default value")
+		cmd.fs.Uint64Var(&uint64NonZero, "uint64-non-zero", uint64NonZero, "uint64 with non-zero default value")
+		cmd.fs.StringVar(&stringZero, "string-zero", stringZero, "string with zero default value")
+		cmd.fs.StringVar(&stringNonZero, "string-non-zero", stringNonZero, "string with non-zero default value")
+		cmd.fs.TextVar(&textZero, "text-zero", textZero, "textvar with zero default value")
+		cmd.fs.TextVar(&textNonZero, "text-non-zero", textNonZero, "textvar with non-zero default value")
+
+		// custom var types
+		var (
+			negatedBoolZero    bool
+			negatedBoolNonZero = true
+			counterZero        uint16
+			counterNonZero     uint16 = 12
+			hiddenZero         time.Time
+			hiddenNonZero      = time.Now()
+			mapZero            = map[string]string{}
+			mapNonZero         = map[string]string{"k": "v"}
+			stringsZero        []string
+			stringsNonZero     = []string{"item"}
+			timeZero           time.Time
+			timeNonZero        = time.UnixMilli(1000 * 60 * 60 * 24 * 3).UTC()
+		)
+		cmd.fs.Var(getopt.NegatedBool(&negatedBoolZero), "neg-bool-zero", "negated bool with zero default value")
+		cmd.fs.Var(getopt.NegatedBool(&negatedBoolNonZero), "neg-bool-non-zero", "negated bool with non-zero default value")
+		cmd.fs.Var(getopt.Counter(&counterZero), "counter-zero", "counter with zero default value")
+		cmd.fs.Var(getopt.Counter(&counterNonZero), "counter-non-zero", "counter with non-zero default value")
+		cmd.fs.Var(&getopt.HiddenVar{Value: getopt.Time(&hiddenZero)}, "hidden-zero", "hidden flag with zero default value")
+		cmd.fs.Var(&getopt.HiddenVar{Value: getopt.Time(&hiddenNonZero)}, "hidden-non-zero", "hidden flag with non-zero default value")
+		cmd.fs.Var(getopt.Map(mapZero), "map-zero", "map flag with zero default value")
+		cmd.fs.Var(getopt.Map(mapNonZero), "map-non-zero", "map flag with non-zero default value")
+		cmd.fs.Var(getopt.Strings(&stringsZero), "strings-zero", "string slice flag with zero default value")
+		cmd.fs.Var(getopt.Strings(&stringsNonZero), "strings-non-zero", "string slice flag with non-zero default value")
+		cmd.fs.Var(getopt.Time(&timeZero), "time-zero", "time flag with zero default value")
+		cmd.fs.Var(getopt.Time(&timeNonZero), "time-non-zero", "time flag with non-zero default value")
+
+		var buf bytes.Buffer
+
+		err := usage(cmd, &ExecuteOptions{
+			usageTemplate: DefaultUsageTemplate,
+			outputWriter:  &buf,
+		})
+		assert(t, nilerr(err))
+
+		t.Logf("result:\n%s", buf.String())
+
+		if diff := cmp.Diff(ExpectedDefaultUsage, buf.String()); diff != "" {
+			t.Fatalf("usage text mismatch (-want +got):\n%s", diff)
+		}
 	})
 }
 
@@ -191,8 +404,8 @@ func TestFlags(t *testing.T) {
 	t.Run("should group bool flags", func(t *testing.T) {
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.Bool("all", false, "bool flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("all"), "a"))
-		cmd.fs.Var(alias(cmd.fs.Lookup("a"), "l"))
+		getopt.Alias(cmd.fs, "all", "a")
+		getopt.Alias(cmd.fs, "a", "l")
 		cmd.fs.Bool("show", false, "bool flag")
 
 		groups := flags(cmd)
@@ -214,8 +427,8 @@ func TestFlags(t *testing.T) {
 	t.Run("should group string flags", func(t *testing.T) {
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.String("from", "HEAD^", "string flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("from"), "b"))
-		cmd.fs.Var(alias(cmd.fs.Lookup("from"), "B"))
+		getopt.Alias(cmd.fs, "from", "b")
+		getopt.Alias(cmd.fs, "from", "B")
 		cmd.fs.String("to", "HEAD", "string flag")
 
 		groups := flags(cmd)
@@ -237,8 +450,8 @@ func TestFlags(t *testing.T) {
 	t.Run("should group duration flags", func(t *testing.T) {
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.Duration("since", time.Minute, "duration flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("since"), "s"))
-		cmd.fs.Var(alias(cmd.fs.Lookup("since"), "f"))
+		getopt.Alias(cmd.fs, "since", "s")
+		getopt.Alias(cmd.fs, "since", "f")
 		cmd.fs.Duration("until", time.Duration(0), "duration flag")
 
 		groups := flags(cmd)
@@ -260,8 +473,8 @@ func TestFlags(t *testing.T) {
 	t.Run("should group float flags", func(t *testing.T) {
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.Float64("epsilon", 0.00001, "float64 flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("epsilon"), "e"))
-		cmd.fs.Var(alias(cmd.fs.Lookup("e"), "ep"))
+		getopt.Alias(cmd.fs, "epsilon", "e")
+		getopt.Alias(cmd.fs, "e", "ep")
 		cmd.fs.Float64("gamma", 0.01, "float64 flag")
 
 		groups := flags(cmd)
@@ -283,9 +496,9 @@ func TestFlags(t *testing.T) {
 	t.Run("should group int flags", func(t *testing.T) {
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.Int("page", 0, "int flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("page"), "p"))
+		getopt.Alias(cmd.fs, "page", "p")
 		cmd.fs.Int("count", 100, "int flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("count"), "c"))
+		getopt.Alias(cmd.fs, "count", "c")
 
 		groups := flags(cmd)
 		assert(t, eq(2, len(groups)))
@@ -306,9 +519,9 @@ func TestFlags(t *testing.T) {
 	t.Run("should group int64 flags", func(t *testing.T) {
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.Int64("page", 0, "int64 flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("page"), "a"))
+		getopt.Alias(cmd.fs, "page", "a")
 		cmd.fs.Int64("count", 100, "int64 flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("count"), "b"))
+		getopt.Alias(cmd.fs, "count", "b")
 
 		groups := flags(cmd)
 		assert(t, eq(2, len(groups)))
@@ -329,9 +542,9 @@ func TestFlags(t *testing.T) {
 	t.Run("should group uint flags", func(t *testing.T) {
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.Uint("page", 0, "uint flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("page"), "x"))
+		getopt.Alias(cmd.fs, "page", "x")
 		cmd.fs.Uint("count", 100, "uint flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("count"), "y"))
+		getopt.Alias(cmd.fs, "count", "y")
 
 		groups := flags(cmd)
 		assert(t, eq(2, len(groups)))
@@ -352,9 +565,9 @@ func TestFlags(t *testing.T) {
 	t.Run("should group uint64 flags", func(t *testing.T) {
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.Uint64("page", 0, "uint64 flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("page"), "px"))
+		getopt.Alias(cmd.fs, "page", "px")
 		cmd.fs.Uint64("count", 100, "uint64 flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("count"), "cx"))
+		getopt.Alias(cmd.fs, "count", "cx")
 
 		groups := flags(cmd)
 		assert(t, eq(2, len(groups)))
@@ -375,9 +588,9 @@ func TestFlags(t *testing.T) {
 	t.Run("should group mapvar flags", func(t *testing.T) {
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.Var(getopt.MapVar{}, "arg", "mapvar flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("arg"), "a"))
+		getopt.Alias(cmd.fs, "arg", "a")
 		cmd.fs.Var(getopt.MapVar{}, "template", "mapvar flag")
-		cmd.fs.Var(alias(cmd.fs.Lookup("template"), "t"))
+		getopt.Alias(cmd.fs, "template", "t")
 
 		groups := flags(cmd)
 		assert(t, eq(2, len(groups)))
@@ -405,9 +618,9 @@ func TestFlags(t *testing.T) {
 
 		cmd.fs = flag.NewFlagSet("cmd", flag.ContinueOnError)
 		cmd.fs.BoolFunc("verbose", "bool func flag", fn1)
-		cmd.fs.Var(alias(cmd.fs.Lookup("verbose"), "v"))
+		getopt.Alias(cmd.fs, "verbose", "v")
 		cmd.fs.Func("optimize", "func flag", fn2)
-		cmd.fs.Var(alias(cmd.fs.Lookup("optimize"), "O"))
+		getopt.Alias(cmd.fs, "optimize", "O")
 
 		groups := flags(cmd)
 		assert(t, eq(2, len(groups)))
@@ -424,8 +637,4 @@ func TestFlags(t *testing.T) {
 		assert(t, eq("O", group[0].Name))
 		assert(t, eq("optimize", group[1].Name))
 	})
-}
-
-func alias(flg *flag.Flag, name string) (flag.Value, string, string) {
-	return flg.Value, name, flg.Usage
 }


### PR DESCRIPTION
When a flag is configured with the zero value for its type, skip rendering the default value in the flag usage output.