### PR TITLE
chore(deps): bump go to 1.26.3

### DIFF
--- a/command.go
+++ b/command.go
@@ -13,7 +13,7 @@ import (
 //
 //   - If you want to configure setup and teardown routines for a command, see [Initializer] and [Destroyer].
 //   - If your command has subcommands, see [RootCommand].
-//   - If your command has command-life flags and switches, see [FlagInitializer].
+//   - If your command has command-line flags and switches, see [FlagInitializer].
 type Command interface {
 	// All commands are [Runnable] and implement a Run routine.
 	Runnable

--- a/example_exec_option_bind_env_test.go
+++ b/example_exec_option_bind_env_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/brandon1024/cmder"
 )
@@ -12,6 +13,7 @@ import (
 func ExampleWithEnvironmentBinding() {
 	os.Setenv("BINDENV_SHOW_FORMAT", "overridden-by-flag")
 	os.Setenv("BINDENV_SHOW_PAGECOUNT", "20")
+	os.Setenv("BINDENV_SHOW_SINCE", "2m")
 
 	args := []string{"show", "--format=pretty"}
 
@@ -26,6 +28,7 @@ func ExampleWithEnvironmentBinding() {
 	// Output:
 	// format: pretty
 	// page-count: 20
+	// since: 2m0s
 }
 
 const BindEnvHelpText = `
@@ -71,13 +74,15 @@ func GetShowCommand() *cmder.BaseCommand {
 }
 
 var (
-	format string = "default"
-	count  uint   = 10
+	format string        = "default"
+	count  uint          = 10
+	since  time.Duration = time.Minute
 )
 
 func showFlags(fs *flag.FlagSet) {
 	fs.StringVar(&format, "format", format, "output format (default, pretty)")
 	fs.UintVar(&count, "page-count", count, "number of pages")
+	fs.DurationVar(&since, "since", since, "show entries since")
 }
 
 func show(ctx context.Context, args []string) error {
@@ -85,7 +90,7 @@ func show(ctx context.Context, args []string) error {
 	case "default":
 		fmt.Printf("%v %v\n", format, count)
 	case "pretty":
-		fmt.Printf("format: %v\npage-count: %v\n", format, count)
+		fmt.Printf("format: %v\npage-count: %v\nsince: %v\n", format, count, since)
 	default:
 		return fmt.Errorf("illegal format: %s", format)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/brandon1024/cmder
 
 go 1.24.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 tool (
 	golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Upgrade Go to 1.26.3. Fix typo in docs and improve examples.